### PR TITLE
Implement all workstreams: data, map, and brief

### DIFF
--- a/server/routes/brief.ts
+++ b/server/routes/brief.ts
@@ -1,10 +1,29 @@
 import { Router } from 'express';
+import type { Request, Response } from 'express';
+import { generateBrief } from '../services/claude.js';
+import type { NeighborhoodProfile } from '../../src/types/index.js';
 
 const router = Router();
 
-router.post('/generate', (_req, res) => {
-  // TODO: call Claude service to generate brief
-  res.status(501).json({ error: 'Not implemented' });
+router.post('/generate', async (req: Request, res: Response) => {
+  try {
+    const { profile, language } = req.body as {
+      profile: NeighborhoodProfile;
+      language: string;
+    };
+
+    if (!profile || !language) {
+      res.status(400).json({ error: 'Missing required fields: profile, language' });
+      return;
+    }
+
+    const brief = await generateBrief(profile, language);
+    res.json(brief);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error generating brief';
+    console.error('Brief generation error:', message);
+    res.status(500).json({ error: message });
+  }
 });
 
 export default router;

--- a/server/routes/demographics.ts
+++ b/server/routes/demographics.ts
@@ -1,15 +1,22 @@
 import { Router } from 'express';
+import { fetchLanguageData } from '../services/census.js';
 
 const router = Router();
 
-router.get('/', (req, res) => {
+router.get('/', async (req, res) => {
   const tract = req.query.tract as string | undefined;
   if (!tract) {
     res.status(400).json({ error: 'tract query parameter is required' });
     return;
   }
-  // TODO: fetch Census language data
-  res.json({});
+
+  try {
+    const demographics = await fetchLanguageData(tract);
+    res.json(demographics);
+  } catch (error) {
+    console.error('Error fetching demographics:', error);
+    res.status(500).json({ error: 'Failed to fetch demographic data' });
+  }
 });
 
 export default router;

--- a/server/routes/locations.ts
+++ b/server/routes/locations.ts
@@ -1,20 +1,36 @@
 import { Router } from 'express';
+import { fetchLibraries, fetchRecCenters, fetchTransitStops } from '../services/soda.js';
 
 const router = Router();
 
-router.get('/libraries', (_req, res) => {
-  // TODO: fetch from SODA API via soda service
-  res.json([]);
+router.get('/libraries', async (_req, res) => {
+  try {
+    const libraries = await fetchLibraries();
+    res.json(libraries);
+  } catch (error) {
+    console.error('Error fetching libraries:', error);
+    res.status(500).json({ error: 'Failed to fetch library data' });
+  }
 });
 
-router.get('/rec-centers', (_req, res) => {
-  // TODO: fetch from SODA API via soda service
-  res.json([]);
+router.get('/rec-centers', async (_req, res) => {
+  try {
+    const centers = await fetchRecCenters();
+    res.json(centers);
+  } catch (error) {
+    console.error('Error fetching rec centers:', error);
+    res.status(500).json({ error: 'Failed to fetch recreation center data' });
+  }
 });
 
-router.get('/transit-stops', (_req, res) => {
-  // TODO: fetch transit stop data
-  res.json([]);
+router.get('/transit-stops', async (_req, res) => {
+  try {
+    const stops = await fetchTransitStops();
+    res.json(stops);
+  } catch (error) {
+    console.error('Error fetching transit stops:', error);
+    res.status(500).json({ error: 'Failed to fetch transit stop data' });
+  }
 });
 
 export default router;

--- a/server/routes/metrics.ts
+++ b/server/routes/metrics.ts
@@ -1,15 +1,79 @@
 import { Router } from 'express';
+import { fetch311 } from '../services/soda.js';
 
 const router = Router();
 
-router.get('/', (req, res) => {
+router.get('/', async (req, res) => {
   const community = req.query.community as string | undefined;
   if (!community) {
     res.status(400).json({ error: 'community query parameter is required' });
     return;
   }
-  // TODO: fetch and aggregate 311 data from SODA API
-  res.json({});
+
+  try {
+    const rows = await fetch311(community);
+
+    const totalRequests311 = rows.length;
+
+    // Identify closed/resolved rows
+    const closedRows = rows.filter(
+      (row) => (row.status || '').toLowerCase() === 'closed'
+    );
+    const resolvedCount = closedRows.length;
+    const resolutionRate =
+      totalRequests311 > 0
+        ? Math.round((resolvedCount / totalRequests311) * 1000) / 1000
+        : 0;
+
+    // Average days to resolve for closed cases
+    let avgDaysToResolve = 0;
+    if (closedRows.length > 0) {
+      const totalDays = closedRows.reduce((sum, row) => {
+        const days = Number(row.case_age_days) || 0;
+        return sum + days;
+      }, 0);
+      avgDaysToResolve = Math.round((totalDays / closedRows.length) * 10) / 10;
+    }
+
+    // Top issues: group by service_name, count, sort desc, top 5
+    const issueCounts: Record<string, number> = {};
+    for (const row of rows) {
+      const category = row.service_name || 'Unknown';
+      issueCounts[category] = (issueCounts[category] || 0) + 1;
+    }
+    const topIssues = Object.entries(issueCounts)
+      .map(([category, count]) => ({ category, count }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 5);
+
+    // Recently resolved: last 5 closed items sorted by date_closed desc
+    const recentlyResolved = closedRows
+      .filter((row) => row.date_closed)
+      .sort((a, b) => {
+        const dateA = new Date(a.date_closed || '').getTime() || 0;
+        const dateB = new Date(b.date_closed || '').getTime() || 0;
+        return dateB - dateA;
+      })
+      .slice(0, 5)
+      .map((row) => ({
+        category: row.service_name || 'Unknown',
+        date: row.date_closed || '',
+      }));
+
+    const metrics = {
+      totalRequests311,
+      resolvedCount,
+      resolutionRate,
+      avgDaysToResolve,
+      topIssues,
+      recentlyResolved,
+    };
+
+    res.json(metrics);
+  } catch (error) {
+    console.error('Error fetching 311 metrics:', error);
+    res.status(500).json({ error: 'Failed to fetch 311 data' });
+  }
 });
 
 export default router;

--- a/server/services/census.ts
+++ b/server/services/census.ts
@@ -1,8 +1,89 @@
 // Census API client for language demographics
 // Data workstream owns this file
 
-export async function fetchLanguageData(tract: string): Promise<unknown> {
-  // TODO: implement with caching
-  void tract;
-  return {};
+import { getCached, setCache } from '../cache.js';
+
+const CENSUS_API_KEY = process.env.CENSUS_API_KEY || '763fa6e6daf21d98f76cfc93e760fe4cb76aa316';
+
+interface LanguageEntry {
+  language: string;
+  percentage: number;
+}
+
+interface LanguageData {
+  topLanguages: LanguageEntry[];
+}
+
+// Map Census field codes to human-readable language names
+const LANGUAGE_FIELDS: Record<string, string> = {
+  C16001_002E: 'English only',
+  C16001_003E: 'Spanish',
+  C16001_006E: 'French/Haitian/Cajun',
+  C16001_009E: 'German/West Germanic',
+  C16001_012E: 'Russian/Polish/Slavic',
+  C16001_015E: 'Korean',
+  C16001_018E: 'Chinese',
+  C16001_021E: 'Vietnamese',
+  C16001_024E: 'Tagalog',
+  C16001_027E: 'Arabic',
+  C16001_030E: 'Other/unspecified',
+};
+
+const FIELDS = [
+  'C16001_001E', // Total pop 5+
+  ...Object.keys(LANGUAGE_FIELDS),
+];
+
+export async function fetchLanguageData(tract: string): Promise<LanguageData> {
+  const cacheKey = `census:language:${tract}`;
+  const cached = await getCached<LanguageData>(cacheKey);
+  if (cached) return cached;
+
+  const fieldList = FIELDS.join(',');
+  const url = `https://api.census.gov/data/2021/acs/acs5?get=${fieldList}&for=tract:${tract}&in=state:06&in=county:073&key=${CENSUS_API_KEY}`;
+
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Census API failed: ${response.status} ${response.statusText}`);
+  }
+
+  const data = (await response.json()) as string[][];
+
+  // Census API returns [headers, ...dataRows]
+  if (!data || data.length < 2) {
+    throw new Error(`No Census data found for tract ${tract}`);
+  }
+
+  const headers = data[0];
+  const values = data[1];
+
+  // Build a lookup from header name to value
+  const lookup: Record<string, number> = {};
+  for (let i = 0; i < headers.length; i++) {
+    lookup[headers[i]] = Number(values[i]) || 0;
+  }
+
+  const totalPop = lookup['C16001_001E'] || 0;
+  if (totalPop === 0) {
+    const result: LanguageData = { topLanguages: [] };
+    await setCache(cacheKey, result);
+    return result;
+  }
+
+  const topLanguages: LanguageEntry[] = [];
+
+  for (const [fieldCode, languageName] of Object.entries(LANGUAGE_FIELDS)) {
+    const count = lookup[fieldCode] || 0;
+    const percentage = Math.round((count / totalPop) * 1000) / 10; // one decimal place
+    if (percentage > 0) {
+      topLanguages.push({ language: languageName, percentage });
+    }
+  }
+
+  // Sort descending by percentage
+  topLanguages.sort((a, b) => b.percentage - a.percentage);
+
+  const result: LanguageData = { topLanguages };
+  await setCache(cacheKey, result);
+  return result;
 }

--- a/server/services/claude.ts
+++ b/server/services/claude.ts
@@ -1,10 +1,81 @@
 // Anthropic Claude API client for brief generation
 // Brief workstream owns this file
 
+import Anthropic from '@anthropic-ai/sdk';
+import type { NeighborhoodProfile, CommunityBrief } from '../../src/types/index.js';
+
+function getClient(): Anthropic {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      'ANTHROPIC_API_KEY is not set. Add it to your .env file.',
+    );
+  }
+  return new Anthropic({ apiKey });
+}
+
 export async function generateBrief(
-  _profile: unknown,
-  _language: string,
-): Promise<unknown> {
-  // TODO: implement Claude API call
-  throw new Error('Not implemented');
+  profile: NeighborhoodProfile,
+  language: string,
+): Promise<CommunityBrief> {
+  const client = getClient();
+
+  const prompt = `You are generating a community brief for the ${profile.communityName} neighborhood of San Diego. The brief will be printed and posted in the community — at a library, rec center, laundromat, or wherever neighbors gather.
+
+Write in ${language}. Use clear, warm, accessible language at a 6th-grade reading level. Avoid jargon.
+
+Here is the data for this neighborhood:
+${JSON.stringify(profile, null, 2)}
+
+Generate a brief with these sections:
+1. **Welcome** — A 2-sentence greeting that names the neighborhood.
+2. **Good News** — 2-3 positive things happening based on the data (resolved issues, investments, improvements).
+3. **What Your Neighbors Are Reporting** — Top 3 issues being reported via 311, framed constructively (not as complaints, but as things the community is working on).
+4. **How to Get Involved** — 3-4 concrete actions: how to file a 311 report, how to attend council meetings, how to contact their council representative, where to find more info.
+5. **Nearby Resources** — List the closest libraries and rec centers with addresses, if available in the data.
+6. **Transit Info** — How many transit stops and routes serve the area.
+
+Keep the total brief under 400 words. It should fit on one printed page.
+
+IMPORTANT: Respond ONLY with valid JSON matching this exact structure:
+{
+  "neighborhoodName": "string",
+  "language": "string",
+  "summary": "string (the Welcome section)",
+  "goodNews": ["string", "string"],
+  "topIssues": ["string", "string", "string"],
+  "howToParticipate": ["string", "string", "string"],
+  "contactInfo": {
+    "councilDistrict": "string",
+    "phone311": "619-236-5311",
+    "anchorLocation": "string (nearest library or rec center with address)"
+  }
+}`;
+
+  try {
+    const message = await client.messages.create({
+      model: 'claude-sonnet-4-6',
+      max_tokens: 1024,
+      messages: [{ role: 'user', content: prompt }],
+    });
+
+    const textBlock = message.content.find((block) => block.type === 'text');
+    if (!textBlock || textBlock.type !== 'text') {
+      throw new Error('No text content in Claude response');
+    }
+
+    const parsed = JSON.parse(textBlock.text) as Omit<CommunityBrief, 'generatedAt'>;
+
+    const brief: CommunityBrief = {
+      ...parsed,
+      generatedAt: new Date().toISOString(),
+    };
+
+    return brief;
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      throw new Error('Failed to parse JSON from Claude response');
+    }
+    throw error;
+  }
 }

--- a/server/services/soda.ts
+++ b/server/services/soda.ts
@@ -1,23 +1,209 @@
 // SODA API client for San Diego open data
 // Data workstream owns this file
 
-export async function fetchLibraries(): Promise<unknown[]> {
-  // TODO: implement with caching
-  return [];
+import { getCached, setCache } from '../cache.js';
+import type { CommunityAnchor } from '../../src/types/index.js';
+
+// --- GeoJSON type helpers ---
+
+interface GeoJsonFeature {
+  type: string;
+  properties: Record<string, unknown>;
+  geometry?: {
+    type: string;
+    coordinates: number[];
+  };
 }
 
-export async function fetchRecCenters(): Promise<unknown[]> {
-  // TODO: implement with caching
-  return [];
+interface GeoJsonCollection {
+  type: string;
+  features: GeoJsonFeature[];
 }
 
-export async function fetchTransitStops(): Promise<unknown[]> {
-  // TODO: implement with caching
-  return [];
+interface TransitStop {
+  id: string;
+  name: string;
+  lat: number;
+  lng: number;
 }
 
-export async function fetch311(community: string): Promise<unknown[]> {
-  // TODO: implement with caching
-  void community;
-  return [];
+interface RawRow {
+  [key: string]: string;
+}
+
+// --- CSV parser (no external dependency) ---
+
+function parseCSV(text: string): RawRow[] {
+  const lines = text.split('\n');
+  if (lines.length < 2) return [];
+
+  const headers = parseCsvLine(lines[0]);
+  const rows: RawRow[] = [];
+
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (!line) continue;
+    const values = parseCsvLine(line);
+    const row: RawRow = {};
+    for (let j = 0; j < headers.length; j++) {
+      row[headers[j].trim()] = (values[j] || '').trim();
+    }
+    rows.push(row);
+  }
+  return rows;
+}
+
+function parseCsvLine(line: string): string[] {
+  const result: string[] = [];
+  let current = '';
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (inQuotes) {
+      if (ch === '"') {
+        if (i + 1 < line.length && line[i + 1] === '"') {
+          current += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        current += ch;
+      }
+    } else {
+      if (ch === '"') {
+        inQuotes = true;
+      } else if (ch === ',') {
+        result.push(current);
+        current = '';
+      } else {
+        current += ch;
+      }
+    }
+  }
+  result.push(current);
+  return result;
+}
+
+// --- Fetch helpers ---
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Fetch failed: ${response.status} ${response.statusText} for ${url}`);
+  }
+  return response.json() as Promise<T>;
+}
+
+async function fetchText(url: string): Promise<string> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Fetch failed: ${response.status} ${response.statusText} for ${url}`);
+  }
+  return response.text();
+}
+
+// --- Public API ---
+
+export async function fetchLibraries(): Promise<CommunityAnchor[]> {
+  const cacheKey = 'soda:libraries';
+  const cached = await getCached<CommunityAnchor[]>(cacheKey);
+  if (cached) return cached;
+
+  const url = 'https://seshat.datasd.org/gis_library_locations/libraries_datasd.geojson';
+  const geojson = await fetchJson<GeoJsonCollection>(url);
+
+  const libraries: CommunityAnchor[] = geojson.features.map((feature, idx) => {
+    const p = feature.properties;
+    const lat = Number(p.lat) || feature.geometry?.coordinates[1] || 0;
+    const lng = Number(p.lng) || feature.geometry?.coordinates[0] || 0;
+
+    return {
+      id: String(p.objectid || idx),
+      name: String(p.name || ''),
+      type: 'library' as const,
+      lat,
+      lng,
+      address: String(p.address || ''),
+      phone: p.phone ? String(p.phone) : undefined,
+      website: p.website ? String(p.website) : undefined,
+      community: '',
+    };
+  });
+
+  await setCache(cacheKey, libraries);
+  return libraries;
+}
+
+export async function fetchRecCenters(): Promise<CommunityAnchor[]> {
+  const cacheKey = 'soda:rec-centers';
+  const cached = await getCached<CommunityAnchor[]>(cacheKey);
+  if (cached) return cached;
+
+  const url = 'https://seshat.datasd.org/gis_recreation_center/rec_centers_datasd.geojson';
+  const geojson = await fetchJson<GeoJsonCollection>(url);
+
+  const centers: CommunityAnchor[] = geojson.features.map((feature, idx) => {
+    const p = feature.properties;
+    const lat = Number(p.lat) || feature.geometry?.coordinates[1] || 0;
+    const lng = Number(p.lng) || feature.geometry?.coordinates[0] || 0;
+    const name = String(p.rec_bldg || p.park_name || '');
+    const neighborhood = String(p.neighborhd || '');
+
+    return {
+      id: String(p.objectid || idx),
+      name,
+      type: 'rec_center' as const,
+      lat,
+      lng,
+      address: String(p.address || ''),
+      community: neighborhood,
+    };
+  });
+
+  await setCache(cacheKey, centers);
+  return centers;
+}
+
+export async function fetchTransitStops(): Promise<TransitStop[]> {
+  const cacheKey = 'soda:transit-stops';
+  const cached = await getCached<TransitStop[]>(cacheKey);
+  if (cached) return cached;
+
+  const url = 'https://seshat.datasd.org/gis_transit_stops/transit_stops_datasd.geojson';
+  const geojson = await fetchJson<GeoJsonCollection>(url);
+
+  const stops: TransitStop[] = geojson.features.map((feature, idx) => {
+    const p = feature.properties;
+    const lat = Number(p.lat) || Number(p.stop_lat) || feature.geometry?.coordinates[1] || 0;
+    const lng = Number(p.lng) || Number(p.stop_lon) || feature.geometry?.coordinates[0] || 0;
+
+    return {
+      id: String(p.stop_uid || p.stop_id || idx),
+      name: String(p.stop_name || ''),
+      lat,
+      lng,
+    };
+  });
+
+  await setCache(cacheKey, stops);
+  return stops;
+}
+
+export async function fetch311(community: string): Promise<RawRow[]> {
+  const cacheKey = 'soda:311-open';
+  let allRows = await getCached<RawRow[]>(cacheKey);
+
+  if (!allRows) {
+    const url = 'https://seshat.datasd.org/get_it_done_reports/get_it_done_requests_open_datasd.csv';
+    const text = await fetchText(url);
+    allRows = parseCSV(text);
+    await setCache(cacheKey, allRows);
+  }
+
+  const normalizedCommunity = community.toLowerCase();
+  return allRows.filter(
+    (row) => (row.comm_plan_name || '').toLowerCase() === normalizedCommunity
+  );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,18 +1,140 @@
+import { useState, useEffect, useCallback } from 'react';
+import SanDiegoMap from './components/map/san-diego-map';
+import NeighborhoodSelector from './components/ui/neighborhood-selector';
+import Sidebar from './components/ui/sidebar';
+import { getLibraries, getRecCenters, getTransitStops, get311, generateBrief } from './api/client';
+import type { CommunityAnchor, CommunityBrief, NeighborhoodProfile } from './types';
+
+
+interface TransitStop {
+  id: string;
+  name: string;
+  lat: number;
+  lng: number;
+}
+
 function App() {
+  const [libraries, setLibraries] = useState<CommunityAnchor[]>([]);
+  const [recCenters, setRecCenters] = useState<CommunityAnchor[]>([]);
+  const [transitStops, setTransitStops] = useState<TransitStop[]>([]);
+
+  const [selectedCommunity, setSelectedCommunity] = useState<string | null>(null);
+  const [selectedAnchor, setSelectedAnchor] = useState<CommunityAnchor | null>(null);
+  const [metrics, setMetrics] = useState<NeighborhoodProfile['metrics'] | null>(null);
+  const [metricsLoading, setMetricsLoading] = useState(false);
+
+  const [brief, setBrief] = useState<CommunityBrief | null>(null);
+  const [briefLoading, setBriefLoading] = useState(false);
+
+  // Fetch map data on mount
+  useEffect(() => {
+    getLibraries().then(setLibraries).catch(console.error);
+    getRecCenters().then(setRecCenters).catch(console.error);
+    getTransitStops()
+      .then((stops) => {
+        // Normalize transit stop shape from the API
+        const normalized: TransitStop[] = (stops as Record<string, unknown>[]).map((s) => ({
+          id: String((s as Record<string, unknown>).id ?? (s as Record<string, unknown>).stop_uid ?? ''),
+          name: String((s as Record<string, unknown>).name ?? (s as Record<string, unknown>).stop_name ?? ''),
+          lat: Number((s as Record<string, unknown>).lat ?? (s as Record<string, unknown>).stop_lat ?? 0),
+          lng: Number((s as Record<string, unknown>).lng ?? (s as Record<string, unknown>).stop_lon ?? 0),
+        }));
+        setTransitStops(normalized);
+      })
+      .catch(console.error);
+  }, []);
+
+  // Fetch 311 metrics when community changes
+  useEffect(() => {
+    if (!selectedCommunity) {
+      setMetrics(null);
+      setBrief(null);
+      return;
+    }
+
+    setMetricsLoading(true);
+    setMetrics(null);
+    setBrief(null);
+
+    get311(selectedCommunity)
+      .then(setMetrics)
+      .catch(console.error)
+      .finally(() => setMetricsLoading(false));
+  }, [selectedCommunity]);
+
+  const handleCommunityChange = useCallback((community: string) => {
+    setSelectedCommunity(community || null);
+    setSelectedAnchor(null);
+  }, []);
+
+  const handleAnchorClick = useCallback((anchor: CommunityAnchor) => {
+    setSelectedAnchor(anchor);
+    setSelectedCommunity(anchor.community);
+  }, []);
+
+  const handleGenerateBrief = useCallback(async () => {
+    if (!selectedCommunity || !metrics) return;
+
+    const anchor = selectedAnchor ?? {
+      id: '',
+      name: selectedCommunity,
+      type: 'library' as const,
+      lat: 0,
+      lng: 0,
+      address: '',
+      community: selectedCommunity,
+    };
+
+    const profile: NeighborhoodProfile = {
+      communityName: selectedCommunity,
+      anchor,
+      metrics,
+      transit: { nearbyStopCount: 0, nearestStopDistance: 0 },
+      demographics: { topLanguages: [] },
+    };
+
+    setBriefLoading(true);
+    try {
+      const result = await generateBrief(profile, 'English');
+      setBrief(result);
+    } catch (err) {
+      console.error('Failed to generate brief:', err);
+    } finally {
+      setBriefLoading(false);
+    }
+  }, [selectedCommunity, selectedAnchor, metrics]);
+
   return (
-    <div className="flex h-screen">
+    <div className="flex h-screen print:block">
       {/* Sidebar */}
-      <aside className="w-80 border-r border-gray-200 p-4 overflow-y-auto">
-        <h1 className="text-xl font-bold mb-4">Block Report</h1>
-        <p className="text-gray-500 text-sm">
-          Select a library or rec center on the map to view its neighborhood
-          profile.
-        </p>
+      <aside className="w-96 shrink-0 border-r border-gray-200 overflow-y-auto flex flex-col print:w-full print:border-none">
+        <div className="p-4 border-b border-gray-100">
+          <h1 className="text-xl font-bold mb-3">Block Report</h1>
+          <NeighborhoodSelector
+            value={selectedCommunity ?? ''}
+            onChange={handleCommunityChange}
+          />
+        </div>
+        <div className="flex-1 overflow-y-auto">
+          <Sidebar
+            community={selectedCommunity}
+            metrics={metrics}
+            loading={metricsLoading}
+            onGenerateBrief={handleGenerateBrief}
+            brief={brief}
+            briefLoading={briefLoading}
+          />
+        </div>
       </aside>
 
-      {/* Map area */}
-      <main className="flex-1 bg-gray-100 flex items-center justify-center">
-        <p className="text-gray-400">Map goes here</p>
+      {/* Map */}
+      <main className="flex-1 print:hidden">
+        <SanDiegoMap
+          libraries={libraries}
+          recCenters={recCenters}
+          transitStops={transitStops}
+          onAnchorClick={handleAnchorClick}
+        />
       </main>
     </div>
   );

--- a/src/app.css
+++ b/src/app.css
@@ -1,1 +1,6 @@
 @import "tailwindcss";
+
+/* Green-tinted marker for rec centers */
+.leaflet-marker-green {
+  filter: hue-rotate(120deg) saturate(1.5);
+}

--- a/src/components/brief/brief-display.tsx
+++ b/src/components/brief/brief-display.tsx
@@ -1,0 +1,128 @@
+import type { CommunityBrief } from '../../types/index';
+
+interface BriefDisplayProps {
+  brief: CommunityBrief | null;
+  loading: boolean;
+}
+
+export function BriefDisplay({ brief, loading }: BriefDisplayProps) {
+  if (loading) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12 text-gray-500">
+        <svg
+          className="animate-spin h-8 w-8 mb-3 text-blue-600"
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+        >
+          <circle
+            className="opacity-25"
+            cx="12"
+            cy="12"
+            r="10"
+            stroke="currentColor"
+            strokeWidth="4"
+          />
+          <path
+            className="opacity-75"
+            fill="currentColor"
+            d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+          />
+        </svg>
+        <p className="text-sm">Generating community brief...</p>
+      </div>
+    );
+  }
+
+  if (!brief) {
+    return null;
+  }
+
+  const formattedDate = new Date(brief.generatedAt).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+
+  return (
+    <div className="brief-content bg-white rounded-lg shadow p-6 max-w-2xl mx-auto">
+      {/* Header */}
+      <div className="border-b border-gray-200 pb-4 mb-4">
+        <h2 className="text-2xl font-bold text-gray-900">
+          {brief.neighborhoodName}
+        </h2>
+        <p className="text-sm text-gray-500 mt-1">
+          Community Brief &middot; {formattedDate} &middot; {brief.language}
+        </p>
+      </div>
+
+      {/* Welcome / Summary */}
+      <section className="mb-5">
+        <p className="text-gray-700 leading-relaxed">{brief.summary}</p>
+      </section>
+
+      {/* Good News */}
+      <section className="mb-5">
+        <h3 className="text-lg font-semibold text-green-700 mb-2">Good News</h3>
+        <ul className="list-disc list-inside space-y-1 text-gray-700">
+          {brief.goodNews.map((item, i) => (
+            <li key={i}>{item}</li>
+          ))}
+        </ul>
+      </section>
+
+      {/* Top Issues */}
+      <section className="mb-5">
+        <h3 className="text-lg font-semibold text-amber-700 mb-2">
+          What Your Neighbors Are Reporting
+        </h3>
+        <ul className="list-disc list-inside space-y-1 text-gray-700">
+          {brief.topIssues.map((item, i) => (
+            <li key={i}>{item}</li>
+          ))}
+        </ul>
+      </section>
+
+      {/* How to Participate */}
+      <section className="mb-5">
+        <h3 className="text-lg font-semibold text-blue-700 mb-2">
+          How to Get Involved
+        </h3>
+        <ul className="list-disc list-inside space-y-1 text-gray-700">
+          {brief.howToParticipate.map((item, i) => (
+            <li key={i}>{item}</li>
+          ))}
+        </ul>
+      </section>
+
+      {/* Contact Info */}
+      <section className="mb-5 bg-gray-50 rounded-md p-4">
+        <h3 className="text-lg font-semibold text-gray-800 mb-2">Contact Info</h3>
+        <dl className="space-y-1 text-sm text-gray-700">
+          <div className="flex gap-2">
+            <dt className="font-medium">Council District:</dt>
+            <dd>{brief.contactInfo.councilDistrict}</dd>
+          </div>
+          <div className="flex gap-2">
+            <dt className="font-medium">311 Phone:</dt>
+            <dd>{brief.contactInfo.phone311}</dd>
+          </div>
+          <div className="flex gap-2">
+            <dt className="font-medium">Nearest Resource:</dt>
+            <dd>{brief.contactInfo.anchorLocation}</dd>
+          </div>
+        </dl>
+      </section>
+
+      {/* Print button */}
+      <div className="no-print mt-4 text-center">
+        <button
+          onClick={() => window.print()}
+          className="px-5 py-2 bg-blue-600 text-white rounded-md text-sm font-medium hover:bg-blue-700 transition-colors cursor-pointer"
+        >
+          Print Brief
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/map/san-diego-map.tsx
+++ b/src/components/map/san-diego-map.tsx
@@ -1,0 +1,116 @@
+import { useCallback } from 'react';
+import { MapContainer, TileLayer, Marker, Popup, CircleMarker } from 'react-leaflet';
+import L from 'leaflet';
+import iconUrl from 'leaflet/dist/images/marker-icon.png';
+import iconRetinaUrl from 'leaflet/dist/images/marker-icon-2x.png';
+import shadowUrl from 'leaflet/dist/images/marker-shadow.png';
+import type { CommunityAnchor } from '../../types';
+
+// Fix Leaflet default icon paths for bundlers
+L.Icon.Default.mergeOptions({ iconUrl, iconRetinaUrl, shadowUrl });
+
+const blueIcon = new L.Icon({
+  iconUrl,
+  iconRetinaUrl,
+  shadowUrl,
+  iconSize: [25, 41],
+  iconAnchor: [12, 41],
+  popupAnchor: [1, -34],
+  shadowSize: [41, 41],
+});
+
+const greenIcon = new L.Icon({
+  iconUrl,
+  iconRetinaUrl,
+  shadowUrl,
+  iconSize: [25, 41],
+  iconAnchor: [12, 41],
+  popupAnchor: [1, -34],
+  shadowSize: [41, 41],
+  className: 'leaflet-marker-green',
+});
+
+interface TransitStop {
+  id: string;
+  name: string;
+  lat: number;
+  lng: number;
+}
+
+interface SanDiegoMapProps {
+  libraries: CommunityAnchor[];
+  recCenters: CommunityAnchor[];
+  transitStops: TransitStop[];
+  onAnchorClick: (anchor: CommunityAnchor) => void;
+}
+
+export default function SanDiegoMap({
+  libraries,
+  recCenters,
+  transitStops,
+  onAnchorClick,
+}: SanDiegoMapProps) {
+  const handleMarkerClick = useCallback(
+    (anchor: CommunityAnchor) => () => {
+      onAnchorClick(anchor);
+    },
+    [onAnchorClick],
+  );
+
+  return (
+    <MapContainer
+      center={[32.7157, -117.1611]}
+      zoom={11}
+      style={{ width: '100%', height: '100%' }}
+    >
+      <TileLayer
+        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+      />
+
+      {/* Transit stops — small gray circles */}
+      {transitStops.map((stop) => (
+        <CircleMarker
+          key={stop.id}
+          center={[stop.lat, stop.lng]}
+          radius={4}
+          pathOptions={{ color: '#9ca3af', fillColor: '#9ca3af', fillOpacity: 0.6, weight: 1 }}
+        >
+          <Popup>{stop.name}</Popup>
+        </CircleMarker>
+      ))}
+
+      {/* Library markers — blue */}
+      {libraries.map((lib) => (
+        <Marker
+          key={lib.id}
+          position={[lib.lat, lib.lng]}
+          icon={blueIcon}
+          eventHandlers={{ click: handleMarkerClick(lib) }}
+        >
+          <Popup>
+            <strong>{lib.name}</strong>
+            <br />
+            {lib.address}
+          </Popup>
+        </Marker>
+      ))}
+
+      {/* Rec center markers — green */}
+      {recCenters.map((rc) => (
+        <Marker
+          key={rc.id}
+          position={[rc.lat, rc.lng]}
+          icon={greenIcon}
+          eventHandlers={{ click: handleMarkerClick(rc) }}
+        >
+          <Popup>
+            <strong>{rc.name}</strong>
+            <br />
+            {rc.address}
+          </Popup>
+        </Marker>
+      ))}
+    </MapContainer>
+  );
+}

--- a/src/components/ui/neighborhood-selector.tsx
+++ b/src/components/ui/neighborhood-selector.tsx
@@ -1,0 +1,66 @@
+const COMMUNITIES = [
+  'Balboa Park',
+  'Barrio Logan',
+  'Bay Ho',
+  'Bay Park',
+  'Carmel Mountain Ranch',
+  'Chollas View',
+  'City Heights',
+  'Clairemont Mesa',
+  'College Area',
+  'Del Cerro',
+  'East Village',
+  'Encanto',
+  'Gaslamp Quarter',
+  'Hillcrest',
+  'Kearny Mesa',
+  'La Jolla',
+  'Linda Vista',
+  'Little Italy',
+  'Logan Heights',
+  'Midway',
+  'Mira Mesa',
+  'Mission Bay',
+  'Mission Hills',
+  'Mission Valley',
+  'Navajo',
+  'Normal Heights',
+  'North Park',
+  'Ocean Beach',
+  'Old Town',
+  'Otay Mesa',
+  'Pacific Beach',
+  'Point Loma',
+  'Rancho Bernardo',
+  'Rancho Penasquitos',
+  'San Ysidro',
+  'Scripps Ranch',
+  'Serra Mesa',
+  'Skyline',
+  'Southeastern',
+  'Tierrasanta',
+  'University City',
+  'Valencia Park',
+] as const;
+
+interface NeighborhoodSelectorProps {
+  value: string;
+  onChange: (community: string) => void;
+}
+
+export default function NeighborhoodSelector({ value, onChange }: NeighborhoodSelectorProps) {
+  return (
+    <select
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      className="w-full rounded border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+    >
+      <option value="">Select a neighborhood...</option>
+      {COMMUNITIES.map((name) => (
+        <option key={name} value={name}>
+          {name}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -1,0 +1,119 @@
+import type { NeighborhoodProfile, CommunityBrief } from '../../types';
+import { BriefDisplay } from '../brief/brief-display';
+
+interface SidebarProps {
+  community: string | null;
+  metrics: NeighborhoodProfile['metrics'] | null;
+  loading: boolean;
+  onGenerateBrief: () => void;
+  brief: CommunityBrief | null;
+  briefLoading: boolean;
+}
+
+function LoadingSpinner() {
+  return (
+    <div className="flex items-center justify-center py-8">
+      <div className="h-8 w-8 animate-spin rounded-full border-4 border-gray-300 border-t-blue-600" />
+    </div>
+  );
+}
+
+export default function Sidebar({
+  community,
+  metrics,
+  loading,
+  onGenerateBrief,
+  brief,
+  briefLoading,
+}: SidebarProps) {
+  if (!community) {
+    return (
+      <div className="p-4 text-gray-500 text-sm">
+        <p>
+          Select a neighborhood from the dropdown above, or click a library or
+          rec center marker on the map to view its community profile.
+        </p>
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="p-4">
+        <h2 className="text-lg font-semibold mb-2">{community}</h2>
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      <h2 className="text-lg font-semibold">{community}</h2>
+
+      {metrics && (
+        <>
+          {/* Summary stats */}
+          <div className="grid grid-cols-2 gap-3">
+            <div className="rounded bg-gray-50 p-3">
+              <p className="text-xs text-gray-500 uppercase tracking-wide">311 Requests</p>
+              <p className="text-xl font-bold">{metrics.totalRequests311.toLocaleString()}</p>
+            </div>
+            <div className="rounded bg-gray-50 p-3">
+              <p className="text-xs text-gray-500 uppercase tracking-wide">Resolution Rate</p>
+              <p className="text-xl font-bold">{(metrics.resolutionRate * 100).toFixed(1)}%</p>
+            </div>
+            <div className="col-span-2 rounded bg-gray-50 p-3">
+              <p className="text-xs text-gray-500 uppercase tracking-wide">Avg Days to Resolve</p>
+              <p className="text-xl font-bold">{metrics.avgDaysToResolve.toFixed(1)}</p>
+            </div>
+          </div>
+
+          {/* Top issues */}
+          {metrics.topIssues.length > 0 && (
+            <div>
+              <h3 className="text-sm font-medium text-gray-700 mb-2">Top Issues</h3>
+              <ul className="space-y-1">
+                {metrics.topIssues.map((issue) => (
+                  <li
+                    key={issue.category}
+                    className="flex items-center justify-between rounded bg-gray-50 px-3 py-1.5 text-sm"
+                  >
+                    <span>{issue.category}</span>
+                    <span className="font-mono text-xs text-gray-500">{issue.count}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {/* Recently resolved */}
+          {metrics.recentlyResolved.length > 0 && (
+            <div>
+              <h3 className="text-sm font-medium text-gray-700 mb-2">Recently Resolved</h3>
+              <ul className="space-y-1 text-sm text-gray-600">
+                {metrics.recentlyResolved.map((item, i) => (
+                  <li key={`${item.category}-${item.date}-${i}`} className="flex justify-between">
+                    <span>{item.category}</span>
+                    <span className="text-xs text-gray-400">{item.date}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {/* Generate brief button */}
+          <button
+            type="button"
+            onClick={onGenerateBrief}
+            disabled={briefLoading}
+            className="w-full rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {briefLoading ? 'Generating...' : 'Generate Brief'}
+          </button>
+        </>
+      )}
+
+      <BriefDisplay brief={brief} loading={briefLoading} />
+    </div>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 import './app.css';
+import './print.css';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/src/print.css
+++ b/src/print.css
@@ -1,1 +1,20 @@
 /* Print-only styles — brief workstream */
+@media print {
+  body * {
+    visibility: hidden;
+  }
+  .brief-content,
+  .brief-content * {
+    visibility: visible;
+  }
+  .brief-content {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100%;
+    padding: 1rem;
+  }
+  .no-print {
+    display: none !important;
+  }
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="vite/client" />
+
+declare module '*.png' {
+  const src: string;
+  export default src;
+}

--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -11,5 +11,5 @@
     "isolatedModules": true,
     "noEmit": true
   },
-  "include": ["server"]
+  "include": ["server", "src/types"]
 }


### PR DESCRIPTION
## Summary

- **Data workstream**: Implement `soda.ts` (GeoJSON/CSV fetch+parse with caching for libraries, rec centers, transit stops, 311), `census.ts` (ACS C16001 language data), and wire up all route handlers (locations, metrics, demographics)
- **Map & frontend workstream**: Build Leaflet map with colored markers, neighborhood selector dropdown (42 SD communities), sidebar with metrics display, and full App composition with state management
- **Brief workstream**: Implement Claude API integration with structured JSON prompt, POST endpoint, brief display component with print button, and print-only CSS

## Test plan

- [ ] Run `npm run dev:all` and verify the map loads with library (blue) and rec center (green) markers
- [ ] Select "Mira Mesa" from the dropdown and verify 311 metrics appear in the sidebar
- [ ] Click a rec center marker and verify its community loads in the sidebar
- [ ] Click "Generate Brief" (requires `ANTHROPIC_API_KEY` in `.env`) and verify the brief renders
- [ ] Click "Print Brief" and verify only the brief content is visible in print preview
- [ ] Test `/api/demographics?tract=008327` endpoint returns language data

🤖 Generated with [Claude Code](https://claude.com/claude-code)