### PR TITLE
Add URL routing for neighborhood pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "leaflet": "^1.9.4",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "react-leaflet": "^5.0.0"
+    "react-leaflet": "^5.0.0",
+    "react-router-dom": "^7.13.1"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       react-leaflet:
         specifier: ^5.0.0
         version: 5.0.0(leaflet@1.9.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react-router-dom:
+        specifier: ^7.13.1
+        version: 7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.2.1
@@ -746,6 +749,10 @@ packages:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
   cors@2.8.6:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
@@ -1119,6 +1126,23 @@ packages:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
     engines: {node: '>=0.10.0'}
 
+  react-router-dom@7.13.1:
+    resolution: {integrity: sha512-UJnV3Rxc5TgUPJt2KJpo1Jpy0OKQr0AjgbZzBFjaPJcFOb2Y8jA5H3LT8HUJAiRLlWrEXWHbF1Z4SCZaQjWDHw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+
+  react-router@7.13.1:
+    resolution: {integrity: sha512-td+xP4X2/6BJvZoX6xw++A2DdEi++YypA69bJUV5oVvqf6/9/9nNlD70YO1e9d3MyamJEBQFEzk6mbfDYbqrSA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
@@ -1159,6 +1183,9 @@ packages:
   serve-static@2.2.1:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
     engines: {node: '>= 18'}
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -1928,6 +1955,8 @@ snapshots:
 
   cookie@0.7.2: {}
 
+  cookie@1.1.1: {}
+
   cors@2.8.6:
     dependencies:
       object-assign: 4.1.1
@@ -2274,6 +2303,20 @@ snapshots:
 
   react-refresh@0.18.0: {}
 
+  react-router-dom@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-router: 7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+
+  react-router@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      cookie: 1.1.1
+      react: 19.2.4
+      set-cookie-parser: 2.7.2
+    optionalDependencies:
+      react-dom: 19.2.4(react@19.2.4)
+
   react@19.2.4: {}
 
   require-directory@2.1.1: {}
@@ -2355,6 +2398,8 @@ snapshots:
       send: 1.2.1
     transitivePeerDependencies:
       - supports-color
+
+  set-cookie-parser@2.7.2: {}
 
   setprototypeof@1.2.0: {}
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,22 @@
 import { useState, useEffect, useCallback } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
 import SanDiegoMap from './components/map/san-diego-map';
 import NeighborhoodSelector from './components/ui/neighborhood-selector';
 import Sidebar from './components/ui/sidebar';
 import { getLibraries, getRecCenters, getTransitStops, get311, generateBrief } from './api/client';
 import type { CommunityAnchor, CommunityBrief, NeighborhoodProfile } from './types';
 
+function toSlug(name: string): string {
+  return name.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
+}
+
+function fromSlug(slug: string): string {
+  // Title-case each word from the slug
+  return slug
+    .split('-')
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
+}
 
 interface TransitStop {
   id: string;
@@ -14,11 +26,16 @@ interface TransitStop {
 }
 
 function App() {
+  const { slug } = useParams<{ slug: string }>();
+  const navigate = useNavigate();
+
   const [libraries, setLibraries] = useState<CommunityAnchor[]>([]);
   const [recCenters, setRecCenters] = useState<CommunityAnchor[]>([]);
   const [transitStops, setTransitStops] = useState<TransitStop[]>([]);
 
-  const [selectedCommunity, setSelectedCommunity] = useState<string | null>(null);
+  const [selectedCommunity, setSelectedCommunity] = useState<string | null>(
+    slug ? fromSlug(slug) : null,
+  );
   const [selectedAnchor, setSelectedAnchor] = useState<CommunityAnchor | null>(null);
   const [metrics, setMetrics] = useState<NeighborhoodProfile['metrics'] | null>(null);
   const [metricsLoading, setMetricsLoading] = useState(false);
@@ -26,13 +43,21 @@ function App() {
   const [brief, setBrief] = useState<CommunityBrief | null>(null);
   const [briefLoading, setBriefLoading] = useState(false);
 
+  // Sync URL → state when slug changes (e.g. browser back/forward)
+  useEffect(() => {
+    const communityFromUrl = slug ? fromSlug(slug) : null;
+    if (communityFromUrl !== selectedCommunity) {
+      setSelectedCommunity(communityFromUrl);
+      setSelectedAnchor(null);
+    }
+  }, [slug]); // eslint-disable-line react-hooks/exhaustive-deps
+
   // Fetch map data on mount
   useEffect(() => {
     getLibraries().then(setLibraries).catch(console.error);
     getRecCenters().then(setRecCenters).catch(console.error);
     getTransitStops()
       .then((stops) => {
-        // Normalize transit stop shape from the API
         const normalized: TransitStop[] = (stops as Record<string, unknown>[]).map((s) => ({
           id: String((s as Record<string, unknown>).id ?? (s as Record<string, unknown>).stop_uid ?? ''),
           name: String((s as Record<string, unknown>).name ?? (s as Record<string, unknown>).stop_name ?? ''),
@@ -62,15 +87,27 @@ function App() {
       .finally(() => setMetricsLoading(false));
   }, [selectedCommunity]);
 
-  const handleCommunityChange = useCallback((community: string) => {
-    setSelectedCommunity(community || null);
-    setSelectedAnchor(null);
-  }, []);
+  const handleCommunityChange = useCallback(
+    (community: string) => {
+      if (community) {
+        navigate(`/neighborhood/${toSlug(community)}`);
+      } else {
+        navigate('/');
+      }
+      setSelectedCommunity(community || null);
+      setSelectedAnchor(null);
+    },
+    [navigate],
+  );
 
-  const handleAnchorClick = useCallback((anchor: CommunityAnchor) => {
-    setSelectedAnchor(anchor);
-    setSelectedCommunity(anchor.community);
-  }, []);
+  const handleAnchorClick = useCallback(
+    (anchor: CommunityAnchor) => {
+      setSelectedAnchor(anchor);
+      setSelectedCommunity(anchor.community);
+      navigate(`/neighborhood/${toSlug(anchor.community)}`);
+    },
+    [navigate],
+  );
 
   const handleGenerateBrief = useCallback(async () => {
     if (!selectedCommunity || !metrics) return;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,11 +1,17 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import App from './App';
 import './app.css';
 import './print.css';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<App />} />
+        <Route path="/neighborhood/:slug" element={<App />} />
+      </Routes>
+    </BrowserRouter>
   </StrictMode>,
 );


### PR DESCRIPTION
## Summary
- Adds `react-router-dom` with `/neighborhood/:slug` routes (e.g. `/neighborhood/mira-mesa`)
- Dropdown selection, map marker clicks, browser back/forward, and direct URL access all stay in sync
- Every neighborhood now has a distinct, shareable URL — ready for QR codes on printed flyers

## Test plan
- [ ] Select a neighborhood from the dropdown — URL updates to `/neighborhood/<slug>`
- [ ] Click a map marker — URL updates to match the marker's community
- [ ] Navigate directly to `/neighborhood/mira-mesa` — page loads with Mira Mesa selected
- [ ] Use browser back/forward — state syncs correctly
- [ ] Clear selection — URL returns to `/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)