### PR TITLE
Gitignore package-lock.json and server/cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,12 @@ supabase/.temp/
 # TypeScript
 *.tsbuildinfo
 
+# Lockfiles (using pnpm)
+package-lock.json
+
+# Server cache
+server/cache/
+
 # Logs
 npm-debug.log*
 yarn-debug.log*


### PR DESCRIPTION
## Summary
- Adds `package-lock.json` to `.gitignore` (project uses pnpm)
- Adds `server/cache/` to `.gitignore` (cached API responses, per CLAUDE.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)