### PR TITLE
Add site-wide navigation with Layout and Navbar

### DIFF
--- a/src/components/layout/layout.tsx
+++ b/src/components/layout/layout.tsx
@@ -1,0 +1,20 @@
+import { Outlet } from 'react-router-dom';
+import Navbar from './navbar';
+
+export default function Layout() {
+  return (
+    <div className="flex flex-col h-screen">
+      {/* Skip to main content — WCAG 2.4.1 */}
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:top-2 focus:left-2 focus:px-4 focus:py-2 focus:bg-white focus:text-blue-700 focus:rounded focus:shadow-lg focus:ring-2 focus:ring-blue-500 focus:outline-none"
+      >
+        Skip to main content
+      </a>
+      <Navbar />
+      <div className="flex-1 overflow-hidden">
+        <Outlet />
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -1,0 +1,81 @@
+import { useState } from 'react';
+import { NavLink } from 'react-router-dom';
+
+const navLinks = [
+  { to: '/', label: 'Home' },
+  { to: '/neighborhood/mira-mesa', label: 'Explore' },
+  { to: '/resources', label: 'Resources' },
+];
+
+function linkClass({ isActive }: { isActive: boolean }) {
+  return `px-3 py-2 rounded-md text-sm font-medium transition-colors ${
+    isActive
+      ? 'text-blue-700 bg-blue-50'
+      : 'text-gray-600 hover:text-gray-900 hover:bg-gray-50'
+  }`;
+}
+
+export default function Navbar() {
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  return (
+    <nav aria-label="Main navigation" className="bg-white border-b border-gray-200 shrink-0 print:hidden">
+      <div className="px-4 flex items-center justify-between h-14">
+        {/* Brand */}
+        <NavLink to="/" className="text-lg font-bold text-gray-900 hover:text-blue-700 transition-colors">
+          Block Report
+        </NavLink>
+
+        {/* Desktop nav links */}
+        <div className="hidden md:flex items-center gap-1">
+          {navLinks.map((link) => (
+            <NavLink key={link.to} to={link.to} className={linkClass} end={link.to === '/'}>
+              {link.label}
+            </NavLink>
+          ))}
+        </div>
+
+        {/* Mobile hamburger */}
+        <button
+          type="button"
+          className="md:hidden p-2 rounded-md text-gray-500 hover:text-gray-900 hover:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+          aria-expanded={menuOpen}
+          aria-controls="mobile-nav-menu"
+          onClick={() => setMenuOpen((v) => !v)}
+        >
+          <span className="sr-only">{menuOpen ? 'Close menu' : 'Open menu'}</span>
+          {menuOpen ? (
+            <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          ) : (
+            <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
+            </svg>
+          )}
+        </button>
+      </div>
+
+      {/* Mobile menu */}
+      {menuOpen && (
+        <div id="mobile-nav-menu" className="md:hidden border-t border-gray-100 px-4 py-2 space-y-1">
+          {navLinks.map((link) => (
+            <NavLink
+              key={link.to}
+              to={link.to}
+              end={link.to === '/'}
+              className={({ isActive }) =>
+                `block px-3 py-2 rounded-md text-sm font-medium ${
+                  isActive ? 'text-blue-700 bg-blue-50' : 'text-gray-600 hover:text-gray-900 hover:bg-gray-50'
+                }`
+              }
+              onClick={() => setMenuOpen(false)}
+            >
+              {link.label}
+            </NavLink>
+          ))}
+        </div>
+      )}
+    </nav>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,8 +1,10 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
-import App from './App';
-import WelcomePage from './components/ui/welcome-page';
+import Layout from './components/layout/layout';
+import WelcomePage from './pages/welcome-page';
+import NeighborhoodPage from './pages/neighborhood-page';
+import ResourcesPage from './pages/resources-page';
 import './app.css';
 import './print.css';
 
@@ -10,8 +12,11 @@ createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <BrowserRouter>
       <Routes>
-        <Route path="/" element={<WelcomePage />} />
-        <Route path="/neighborhood/:slug" element={<App />} />
+        <Route element={<Layout />}>
+          <Route path="/" element={<WelcomePage />} />
+          <Route path="/neighborhood/:slug" element={<NeighborhoodPage />} />
+          <Route path="/resources" element={<ResourcesPage />} />
+        </Route>
       </Routes>
     </BrowserRouter>
   </StrictMode>,

--- a/src/pages/neighborhood-page.tsx
+++ b/src/pages/neighborhood-page.tsx
@@ -1,23 +1,12 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import SanDiegoMap from './components/map/san-diego-map';
-import NeighborhoodSelector from './components/ui/neighborhood-selector';
-import Sidebar from './components/ui/sidebar';
-import { getLibraries, getRecCenters, getTransitStops, get311, generateBrief, getNeighborhoodBoundaries } from './api/client';
-import type { CommunityAnchor, CommunityBrief, NeighborhoodProfile } from './types';
+import SanDiegoMap from '../components/map/san-diego-map';
+import NeighborhoodSelector from '../components/ui/neighborhood-selector';
+import Sidebar from '../components/ui/sidebar';
+import { getLibraries, getRecCenters, getTransitStops, get311, generateBrief, getNeighborhoodBoundaries } from '../api/client';
+import type { CommunityAnchor, CommunityBrief, NeighborhoodProfile } from '../types';
 import type { FeatureCollection } from 'geojson';
-
-function toSlug(name: string): string {
-  return name.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
-}
-
-function fromSlug(slug: string): string {
-  // Title-case each word from the slug
-  return slug
-    .split('-')
-    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
-    .join(' ');
-}
+import { toSlug, fromSlug } from '../utils/slug';
 
 interface TransitStop {
   id: string;
@@ -26,7 +15,7 @@ interface TransitStop {
   lng: number;
 }
 
-function App() {
+export default function NeighborhoodPage() {
   const { slug } = useParams<{ slug: string }>();
   const navigate = useNavigate();
   const [mobileView, setMobileView] = useState<'map' | 'info'>('map');
@@ -149,24 +138,7 @@ function App() {
   }, [selectedCommunity, selectedAnchor, metrics]);
 
   return (
-    <div className="flex flex-col h-screen md:flex-row print:block">
-      {/* Skip to main content — WCAG 2.4.1 */}
-      <a
-        href="#main-content"
-        className="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:top-2 focus:left-2 focus:px-4 focus:py-2 focus:bg-white focus:text-blue-700 focus:rounded focus:shadow-lg focus:ring-2 focus:ring-blue-500 focus:outline-none"
-      >
-        Skip to main content
-      </a>
-
-      {/* Mobile header — title + selector, hidden on desktop */}
-      <header className="md:hidden flex items-center gap-3 px-4 py-3 border-b border-gray-200 bg-white shrink-0 print:hidden">
-        <h1 className="text-base font-bold shrink-0">Block Report</h1>
-        <NeighborhoodSelector
-          value={selectedCommunity ?? ''}
-          onChange={(c) => { handleCommunityChange(c); if (c) setMobileView('info'); }}
-        />
-      </header>
-
+    <div className="flex flex-col h-full md:flex-row print:block">
       {/* Sidebar — full panel on desktop, shown on mobile only in 'info' tab */}
       <aside
         id="panel-info"
@@ -178,12 +150,11 @@ function App() {
           ${mobileView === 'info' ? 'flex' : 'hidden md:flex'}
         `}
       >
-        {/* Desktop-only header inside sidebar */}
-        <div className="hidden md:block p-4 border-b border-gray-100 shrink-0">
-          <h1 className="text-xl font-bold mb-3">Block Report</h1>
+        {/* Sidebar header with neighborhood selector */}
+        <div className="p-4 border-b border-gray-100 shrink-0">
           <NeighborhoodSelector
             value={selectedCommunity ?? ''}
-            onChange={handleCommunityChange}
+            onChange={(c) => { handleCommunityChange(c); if (c) setMobileView('info'); }}
           />
         </div>
         <div className="flex-1 overflow-y-auto">
@@ -256,5 +227,3 @@ function App() {
     </div>
   );
 }
-
-export default App;

--- a/src/pages/resources-page.tsx
+++ b/src/pages/resources-page.tsx
@@ -1,0 +1,70 @@
+import { useState, useEffect } from 'react';
+import { getLibraries, getRecCenters } from '../api/client';
+import type { CommunityAnchor } from '../types';
+
+export default function ResourcesPage() {
+  const [libraries, setLibraries] = useState<CommunityAnchor[]>([]);
+  const [recCenters, setRecCenters] = useState<CommunityAnchor[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    Promise.all([getLibraries(), getRecCenters()])
+      .then(([libs, recs]) => {
+        setLibraries(libs);
+        setRecCenters(recs);
+      })
+      .catch(console.error)
+      .finally(() => setLoading(false));
+  }, []);
+
+  return (
+    <div id="main-content" className="h-full overflow-y-auto">
+      <div className="max-w-4xl mx-auto px-4 py-12">
+        <h1 className="text-3xl font-bold text-gray-900 mb-2">Community Resources</h1>
+        <p className="text-gray-600 mb-8">
+          Libraries, recreation centers, and civic essentials across San Diego.
+        </p>
+
+        {loading ? (
+          <p className="text-gray-500">Loading resources...</p>
+        ) : (
+          <div className="space-y-10">
+            <section>
+              <h2 className="text-xl font-semibold text-gray-800 mb-4">
+                Libraries ({libraries.length})
+              </h2>
+              <div className="grid gap-3 sm:grid-cols-2">
+                {libraries.map((lib) => (
+                  <div key={lib.id} className="p-4 bg-white border border-gray-200 rounded-lg">
+                    <p className="font-medium text-gray-900">{lib.name}</p>
+                    {lib.address && <p className="text-sm text-gray-500 mt-1">{lib.address}</p>}
+                    {lib.community && (
+                      <p className="text-xs text-gray-400 mt-1">{lib.community}</p>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </section>
+
+            <section>
+              <h2 className="text-xl font-semibold text-gray-800 mb-4">
+                Recreation Centers ({recCenters.length})
+              </h2>
+              <div className="grid gap-3 sm:grid-cols-2">
+                {recCenters.map((rc) => (
+                  <div key={rc.id} className="p-4 bg-white border border-gray-200 rounded-lg">
+                    <p className="font-medium text-gray-900">{rc.name}</p>
+                    {rc.address && <p className="text-sm text-gray-500 mt-1">{rc.address}</p>}
+                    {rc.community && (
+                      <p className="text-xs text-gray-400 mt-1">{rc.community}</p>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </section>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/welcome-page.tsx
+++ b/src/pages/welcome-page.tsx
@@ -1,10 +1,7 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { COMMUNITIES } from './neighborhood-selector';
-
-function toSlug(name: string): string {
-  return name.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
-}
+import { COMMUNITIES } from '../components/ui/neighborhood-selector';
+import { toSlug } from '../utils/slug';
 
 const QUESTION_TILES = [
   {
@@ -42,12 +39,7 @@ export default function WelcomePage() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 flex flex-col">
-      {/* Header */}
-      <header className="bg-white border-b border-gray-200 px-4 py-3">
-        <h1 className="text-lg font-bold text-gray-900">Block Report</h1>
-      </header>
-
+    <div className="h-full overflow-y-auto bg-gray-50 flex flex-col">
       <main id="main-content" className="flex-1 px-4 py-8 max-w-2xl mx-auto w-full">
 
         {/* Hero */}
@@ -72,7 +64,7 @@ export default function WelcomePage() {
                 onChange={(e) => setSelected(e.target.value)}
                 className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2.5 text-sm text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
               >
-                <option value="">Pick a neighborhood…</option>
+                <option value="">Pick a neighborhood...</option>
                 {COMMUNITIES.map((name) => (
                   <option key={name} value={name}>{name}</option>
                 ))}

--- a/src/print.css
+++ b/src/print.css
@@ -14,7 +14,8 @@
     width: 100%;
     padding: 1rem;
   }
-  .no-print {
+  .no-print,
+  nav[aria-label="Main navigation"] {
     display: none !important;
   }
 }

--- a/src/utils/slug.ts
+++ b/src/utils/slug.ts
@@ -1,0 +1,10 @@
+export function toSlug(name: string): string {
+  return name.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
+}
+
+export function fromSlug(slug: string): string {
+  return slug
+    .split('-')
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
+}


### PR DESCRIPTION
## Summary
- Adds a shared **Layout** component (skip-to-content link + responsive Navbar + Outlet) wrapping all routes
- Refactors `App.tsx` into `NeighborhoodPage` — removes embedded branding (now in Navbar), uses `h-full` instead of `h-screen` so the map fills below the navbar
- Adds **WelcomePage** (adapted from upstream's question tiles + neighborhood picker) and **ResourcesPage** (lists libraries + rec centers from API)
- Wires three-route structure: `/` → Welcome, `/neighborhood/:slug` → Neighborhood, `/resources` → Resources
- Extracts `toSlug`/`fromSlug` to `src/utils/slug.ts` for reuse across pages
- Navbar hidden in print via `src/print.css`

## Test plan
- [ ] `npm run build` passes with no errors
- [ ] Visit `/` — welcome page renders with neighborhood picker and question tiles
- [ ] Click a neighborhood — navigates to `/neighborhood/:slug`, map fills viewport below navbar
- [ ] Visit `/resources` — libraries and rec centers load and display
- [ ] Mobile: hamburger menu opens/closes, bottom tab bar still works on neighborhood page
- [ ] Browser back/forward works across all pages
- [ ] Print preview: navbar hidden, brief content prints correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)