### PR TITLE
Add flyer-style print layout for community briefs

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "csv-parse": "^6.1.0",
     "express": "^5.2.1",
     "leaflet": "^1.9.4",
+    "qrcode.react": "^4.2.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-leaflet": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       leaflet:
         specifier: ^1.9.4
         version: 1.9.4
+      qrcode.react:
+        specifier: ^4.2.0
+        version: 4.2.0(react@19.2.4)
       react:
         specifier: ^19.2.4
         version: 19.2.4
@@ -1100,6 +1103,11 @@ packages:
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
+
+  qrcode.react@4.2.0:
+    resolution: {integrity: sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   qs@6.15.0:
     resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
@@ -2278,6 +2286,10 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
+
+  qrcode.react@4.2.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
 
   qs@6.15.0:
     dependencies:

--- a/src/components/brief/brief-display.tsx
+++ b/src/components/brief/brief-display.tsx
@@ -1,5 +1,7 @@
 import type { CommunityBrief } from '../../types/index';
 import { useLanguage } from '../../i18n/context';
+import { BriefFlyer } from './brief-flyer';
+import { toSlug } from '../../utils/slug';
 
 interface BriefDisplayProps {
   brief: CommunityBrief | null;
@@ -129,6 +131,12 @@ export function BriefDisplay({ brief, loading }: BriefDisplayProps) {
           {t('brief.print')}
         </button>
       </div>
+
+      {/* Flyer layout — hidden on screen, shown when printing */}
+      <BriefFlyer
+        brief={brief}
+        neighborhoodSlug={toSlug(brief.neighborhoodName)}
+      />
     </div>
   );
 }

--- a/src/components/brief/brief-flyer.tsx
+++ b/src/components/brief/brief-flyer.tsx
@@ -1,0 +1,130 @@
+import { QRCodeSVG } from 'qrcode.react';
+import type { CommunityBrief } from '../../types/index';
+import {
+  MegaphoneIcon,
+  AlertTriangleIcon,
+  HandRaisedIcon,
+  PhoneIcon,
+  MapPinIcon,
+  BuildingIcon,
+} from './flyer-icons';
+
+interface BriefFlyerProps {
+  brief: CommunityBrief;
+  neighborhoodSlug: string;
+}
+
+export function BriefFlyer({ brief, neighborhoodSlug }: BriefFlyerProps) {
+  const formattedDate = new Date(brief.generatedAt).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+
+  const qrUrl = `${window.location.origin}/neighborhood/${neighborhoodSlug}`;
+
+  return (
+    <div className="brief-flyer hidden print:block text-black">
+      {/* Header Banner */}
+      <div className="border-b-4 border-black pb-2 mb-3">
+        <p className="text-xs font-bold uppercase tracking-[0.3em]">Block Report</p>
+        <h1 className="text-3xl font-black uppercase leading-tight">
+          {brief.neighborhoodName}
+        </h1>
+        <p className="text-sm font-medium">
+          Community Brief &middot; {formattedDate} &middot; {brief.language}
+        </p>
+      </div>
+
+      {/* Summary */}
+      <div className="mb-3">
+        <p className="text-sm leading-snug">{brief.summary}</p>
+      </div>
+
+      {/* Two-column: Good News + Top Issues */}
+      <div className="grid grid-cols-2 gap-4 mb-3">
+        <div className="flyer-section border-2 border-black rounded p-2">
+          <div className="flex items-center gap-1.5 mb-1.5 border-b border-black pb-1">
+            <MegaphoneIcon className="w-4 h-4" />
+            <h2 className="text-xs font-black uppercase tracking-widest">Good News</h2>
+          </div>
+          <ul className="text-xs space-y-1 list-none">
+            {brief.goodNews.slice(0, 4).map((item, i) => (
+              <li key={i} className="flex gap-1">
+                <span className="font-bold flex-shrink-0">&bull;</span>
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div className="flyer-section border-2 border-black rounded p-2">
+          <div className="flex items-center gap-1.5 mb-1.5 border-b border-black pb-1">
+            <AlertTriangleIcon className="w-4 h-4" />
+            <h2 className="text-xs font-black uppercase tracking-widest">Neighbors Report</h2>
+          </div>
+          <ul className="text-xs space-y-1 list-none">
+            {brief.topIssues.slice(0, 4).map((item, i) => (
+              <li key={i} className="flex gap-1">
+                <span className="font-bold flex-shrink-0">&bull;</span>
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+
+      {/* How to Get Involved — full width */}
+      <div className="flyer-section border-2 border-black rounded p-2 mb-3">
+        <div className="flex items-center gap-1.5 mb-1.5 border-b border-black pb-1">
+          <HandRaisedIcon className="w-4 h-4" />
+          <h2 className="text-xs font-black uppercase tracking-widest">Get Involved</h2>
+        </div>
+        <ul className="text-xs space-y-1 list-none">
+          {brief.howToParticipate.slice(0, 4).map((item, i) => (
+            <li key={i} className="flex gap-1">
+              <span className="font-bold flex-shrink-0">&bull;</span>
+              <span>{item}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      {/* Footer: Contact + QR */}
+      <div className="grid grid-cols-[1fr_auto] gap-4 border-t-2 border-black pt-2">
+        <div className="flyer-section">
+          <h2 className="text-xs font-black uppercase tracking-widest mb-1.5">Contact</h2>
+          <dl className="text-xs space-y-1">
+            <div className="flex items-center gap-1.5">
+              <PhoneIcon className="w-3.5 h-3.5 flex-shrink-0" />
+              <dt className="sr-only">311 Phone</dt>
+              <dd>{brief.contactInfo.phone311}</dd>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <BuildingIcon className="w-3.5 h-3.5 flex-shrink-0" />
+              <dt className="sr-only">Council District</dt>
+              <dd>{brief.contactInfo.councilDistrict}</dd>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <MapPinIcon className="w-3.5 h-3.5 flex-shrink-0" />
+              <dt className="sr-only">Nearest Resource</dt>
+              <dd>{brief.contactInfo.anchorLocation}</dd>
+            </div>
+          </dl>
+        </div>
+
+        <div className="flex flex-col items-center">
+          <QRCodeSVG value={qrUrl} size={72} level="M" />
+          <p className="text-[9px] mt-1 text-center font-medium">Scan to view online</p>
+        </div>
+      </div>
+
+      {/* Bottom tagline */}
+      <div className="border-t border-black mt-2 pt-1 text-center">
+        <p className="text-[9px] font-medium tracking-wide">
+          Block Report &middot; Your neighborhood, your voice
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/brief/flyer-icons.tsx
+++ b/src/components/brief/flyer-icons.tsx
@@ -1,0 +1,69 @@
+interface IconProps {
+  className?: string;
+}
+
+export function MegaphoneIcon({ className = 'w-5 h-5' }: IconProps) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M18 8a6 6 0 0 0-6-6v20a6 6 0 0 0 6-6V8z" />
+      <path d="M2 12h4" />
+      <path d="M6 8v8" />
+      <path d="M6 8l6-6" />
+      <path d="M6 16l6 6" />
+      <circle cx="20" cy="12" r="2" />
+    </svg>
+  );
+}
+
+export function AlertTriangleIcon({ className = 'w-5 h-5' }: IconProps) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+      <line x1="12" y1="9" x2="12" y2="13" />
+      <line x1="12" y1="17" x2="12.01" y2="17" />
+    </svg>
+  );
+}
+
+export function HandRaisedIcon({ className = 'w-5 h-5' }: IconProps) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M18 11V6a2 2 0 0 0-4 0v1" />
+      <path d="M14 10V4a2 2 0 0 0-4 0v6" />
+      <path d="M10 10.5V6a2 2 0 0 0-4 0v8" />
+      <path d="M18 8a2 2 0 1 1 4 0v6a8 8 0 0 1-8 8H12a8 8 0 0 1-6-3" />
+    </svg>
+  );
+}
+
+export function PhoneIcon({ className = 'w-5 h-5' }: IconProps) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6A19.79 19.79 0 0 1 2.12 4.18 2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72c.127.96.362 1.903.7 2.81a2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45c.907.338 1.85.573 2.81.7A2 2 0 0 1 22 16.92z" />
+    </svg>
+  );
+}
+
+export function MapPinIcon({ className = 'w-5 h-5' }: IconProps) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z" />
+      <circle cx="12" cy="10" r="3" />
+    </svg>
+  );
+}
+
+export function BuildingIcon({ className = 'w-5 h-5' }: IconProps) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="4" y="2" width="16" height="20" rx="2" ry="2" />
+      <path d="M9 22V12h6v10" />
+      <path d="M8 6h.01" />
+      <path d="M16 6h.01" />
+      <path d="M12 6h.01" />
+      <path d="M12 10h.01" />
+      <path d="M8 10h.01" />
+      <path d="M16 10h.01" />
+    </svg>
+  );
+}

--- a/src/print.css
+++ b/src/print.css
@@ -1,21 +1,35 @@
 /* Print-only styles — brief workstream */
 @media print {
+  @page {
+    size: letter portrait;
+    margin: 0.5in;
+  }
+
   body * {
     visibility: hidden;
   }
-  .brief-content,
-  .brief-content * {
+
+  .brief-flyer,
+  .brief-flyer * {
     visibility: visible;
   }
-  .brief-content {
+
+  .brief-flyer {
     position: absolute;
     left: 0;
     top: 0;
     width: 100%;
-    padding: 1rem;
   }
+
+  /* Hide screen-only elements */
   .no-print,
+  .brief-content,
   nav[aria-label="Main navigation"] {
     display: none !important;
+  }
+
+  /* Keep sections together */
+  .flyer-section {
+    break-inside: avoid;
   }
 }


### PR DESCRIPTION
## Summary
- Adds a new `BriefFlyer` component with a community flyer layout (two-column grid, bold headers, inline SVG icons, QR code)
- Updates `print.css` with `@page` sizing for US Letter and flyer-specific visibility rules
- Installs `qrcode.react` for client-side QR code generation
- Flyer is hidden on screen (`hidden print:block`) and shown only when printing

## Test plan
- [ ] Navigate to a neighborhood, generate a brief, click "Print Brief"
- [ ] Verify print preview shows flyer layout fitting one US Letter page
- [ ] Verify B&W readability (no color-dependent elements)
- [ ] Verify QR code renders and is scannable

Fixes #9