### PR TITLE
Add per-neighborhood 311 engagement rate

### DIFF
--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -48,6 +48,40 @@ function parseInt_(val: string | undefined): number | null {
   return isNaN(n) ? null : n;
 }
 
+// --- Geo helpers ---
+
+type Polygon = number[][][]; // [ring][point][lng, lat]
+
+// Ray-casting point-in-polygon test
+function pointInPolygon(lat: number, lng: number, polygon: Polygon): boolean {
+  for (const ring of polygon) {
+    let inside = false;
+    for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
+      const xi = ring[i][1], yi = ring[i][0]; // GeoJSON is [lng, lat]
+      const xj = ring[j][1], yj = ring[j][0];
+      if ((yi > lng) !== (yj > lng) && lat < ((xj - xi) * (lng - yi)) / (yj - yi) + xi) {
+        inside = !inside;
+      }
+    }
+    if (inside) return true;
+  }
+  return false;
+}
+
+interface CommunityFeature {
+  name: string;
+  polygons: Polygon[];
+}
+
+function findCommunity(lat: number, lng: number, communities: CommunityFeature[]): string | null {
+  for (const c of communities) {
+    for (const poly of c.polygons) {
+      if (pointInPolygon(lat, lng, poly)) return c.name;
+    }
+  }
+  return null;
+}
+
 // --- Seeders ---
 
 async function seedLibraries() {
@@ -228,6 +262,77 @@ async function seedCensusLanguage() {
 
   const count = await batchInsert('census_language', mapped);
   console.log(`  ✓ ${count} Census tracts`);
+
+  // Map tracts to communities using centroids + community boundaries
+  await mapTractsToCommunitites(censusKey, rows);
+}
+
+async function mapTractsToCommunitites(censusKey: string, censusRows: string[][]) {
+  console.log('Mapping Census tracts to communities...');
+
+  // Fetch community boundaries GeoJSON
+  console.log('  Fetching community boundaries...');
+  const boundaryRes = await fetch(
+    'https://seshat.datasd.org/gis_community_planning_districts/cmty_plan_datasd.geojson'
+  );
+  if (!boundaryRes.ok) {
+    console.log('  ⚠ Failed to fetch community boundaries, skipping tract mapping');
+    return;
+  }
+  const boundaries = await boundaryRes.json();
+
+  // Parse community features
+  const communities: CommunityFeature[] = [];
+  for (const feature of boundaries.features) {
+    const name = toTitleCase((feature.properties.cpname || feature.properties.name || '').trim());
+    if (!name) continue;
+    const geom = feature.geometry;
+    const polygons: Polygon[] =
+      geom.type === 'MultiPolygon' ? geom.coordinates : [geom.coordinates];
+    communities.push({ name, polygons });
+  }
+  console.log(`  ${communities.length} community boundaries loaded`);
+
+  // Fetch tract centroids from TIGERweb
+  console.log('  Fetching tract centroids from TIGERweb...');
+  const tigerUrl =
+    'https://tigerweb.geo.census.gov/arcrest/services/TIGERweb/tigerWMS_ACS2021/MapServer/8/query' +
+    "?where=STATE='06'+AND+COUNTY='073'&outFields=TRACT,CENTLAT,CENTLON&f=json&returnGeometry=false";
+  const tigerRes = await fetch(tigerUrl);
+  if (!tigerRes.ok) {
+    console.log('  ⚠ Failed to fetch tract centroids, skipping tract mapping');
+    return;
+  }
+  const tigerData = await tigerRes.json();
+
+  // Build tract → centroid map
+  const tractCentroids = new Map<string, { lat: number; lng: number }>();
+  for (const feat of tigerData.features || []) {
+    const attrs = feat.attributes || feat.properties;
+    if (attrs?.TRACT && attrs.CENTLAT != null && attrs.CENTLON != null) {
+      tractCentroids.set(attrs.TRACT, { lat: Number(attrs.CENTLAT), lng: Number(attrs.CENTLON) });
+    }
+  }
+  console.log(`  ${tractCentroids.size} tract centroids loaded`);
+
+  // Match each tract to a community
+  let mapped = 0;
+  for (const row of censusRows) {
+    const tract = row[row.length - 1];
+    const centroid = tractCentroids.get(tract);
+    if (!centroid) continue;
+
+    const community = findCommunity(centroid.lat, centroid.lng, communities);
+    if (!community) continue;
+
+    const { error } = await supabase
+      .from('census_language')
+      .update({ community })
+      .eq('tract', tract);
+
+    if (!error) mapped++;
+  }
+  console.log(`  ✓ ${mapped} tracts mapped to communities`);
 }
 
 // --- Main ---

--- a/server/routes/metrics.ts
+++ b/server/routes/metrics.ts
@@ -29,6 +29,16 @@ router.get('/', async (req, res) => {
     return;
   }
 
+  // Fetch population for this community from census data
+  const { data: censusData } = await supabase
+    .from('census_language')
+    .select('total_pop_5plus')
+    .ilike('community', cleaned);
+
+  const population = censusData
+    ? censusData.reduce((sum, row) => sum + (Number(row.total_pop_5plus) || 0), 0)
+    : 0;
+
   const total = data.length;
   const resolved = data.filter(
     (r) => r.status === 'Closed' || r.date_closed
@@ -73,6 +83,11 @@ router.get('/', async (req, res) => {
       date: r.date_closed,
     }));
 
+  const requestsPer1000Residents =
+    population > 0
+      ? Math.round((total / population) * 1000 * 10) / 10
+      : null;
+
   res.json({
     totalRequests311: total,
     resolvedCount,
@@ -80,6 +95,8 @@ router.get('/', async (req, res) => {
     avgDaysToResolve: Math.round(avgDaysToResolve * 10) / 10,
     topIssues,
     recentlyResolved,
+    population,
+    requestsPer1000Residents,
   });
 });
 

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -107,9 +107,14 @@ export default function Sidebar({
           {/* Narrative summary */}
           <section aria-labelledby="summary-heading">
             <h2 id="summary-heading" className="sr-only">{t('sidebar.neighborhoodSummary')}</h2>
-            <p className="text-sm text-gray-700 mb-3">
+            <p className="text-sm text-gray-700 mb-1">
               {t('sidebar.requestsSummary', { count: metrics.totalRequests311.toLocaleString() })}
             </p>
+            {metrics.requestsPer1000Residents != null && metrics.population > 0 && (
+              <p className="text-sm text-gray-600 mb-3">
+                Residents here report about <span className="font-semibold">{metrics.requestsPer1000Residents}</span> issues per 1,000 people.
+              </p>
+            )}
             <div className="flex flex-wrap gap-2">
               {resolutionBadge(metrics.resolutionRate)}
               {responseBadge(metrics.avgDaysToResolve)}
@@ -139,6 +144,18 @@ export default function Sidebar({
                   <dt className="text-gray-500">{t('sidebar.avgDays')}</dt>
                   <dd className="font-mono font-medium">{metrics.avgDaysToResolve.toFixed(1)}</dd>
                 </div>
+                {metrics.population > 0 && (
+                  <div className="flex justify-between">
+                    <dt className="text-gray-500">Est. population</dt>
+                    <dd className="font-mono font-medium">{metrics.population.toLocaleString()}</dd>
+                  </div>
+                )}
+                {metrics.requestsPer1000Residents != null && (
+                  <div className="flex justify-between">
+                    <dt className="text-gray-500">Requests per 1,000</dt>
+                    <dd className="font-mono font-medium">{metrics.requestsPer1000Residents}</dd>
+                  </div>
+                )}
               </dl>
             )}
           </section>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -20,6 +20,8 @@ export interface NeighborhoodProfile {
     avgDaysToResolve: number;
     topIssues: { category: string; count: number }[];
     recentlyResolved: { category: string; date: string }[];
+    population: number;
+    requestsPer1000Residents: number | null;
   };
   transit: {
     nearbyStopCount: number;

--- a/supabase/migrations/00002_add_census_community.sql
+++ b/supabase/migrations/00002_add_census_community.sql
@@ -1,0 +1,3 @@
+-- Add community column to census_language for tract-to-community mapping
+ALTER TABLE census_language ADD COLUMN community TEXT;
+CREATE INDEX idx_census_community ON census_language (community);


### PR DESCRIPTION
## Summary
- Computes **requests per 1,000 residents** for each community, normalizing raw 311 counts by Census population data
- Maps Census tracts to San Diego community planning areas using point-in-polygon with community boundary GeoJSON and TIGERweb tract centroids
- Displays the engagement rate in the sidebar both as a narrative sentence and in the detailed stats panel

## Changes
- **`supabase/migrations/00002_add_census_community.sql`** — Adds `community` column + index to `census_language`
- **`scripts/seed.ts`** — After seeding Census data, fetches community boundaries and tract centroids, maps each tract to its community via point-in-polygon
- **`server/routes/metrics.ts`** — Queries census population by community, returns `population` and `requestsPer1000Residents` alongside existing metrics
- **`src/types/index.ts`** — Adds `population` and `requestsPer1000Residents` to `NeighborhoodProfile.metrics`
- **`src/components/ui/sidebar.tsx`** — Shows per-capita rate in narrative form ("Residents here report about X issues per 1,000 people") and in the expandable details panel

## Test plan
- [ ] Run the seed script with `CENSUS_API_KEY` set — verify tracts are mapped to communities in logs
- [ ] Hit `/api/311?community=Mira Mesa` — verify response includes `population` and `requestsPer1000Residents`
- [ ] Select a neighborhood in the UI — verify the engagement rate appears in the sidebar
- [ ] Test with a community that has no Census data — verify graceful degradation (`requestsPer1000Residents: null`)

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)