### PR TITLE
Fix map markers all showing as Rec Center

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -16,12 +16,14 @@ async function fetchJSON<T>(url: string, init?: RequestInit): Promise<T> {
   return res.json() as Promise<T>;
 }
 
-export function getLibraries(): Promise<CommunityAnchor[]> {
-  return fetchJSON(`${BASE}/locations/libraries`);
+export async function getLibraries(): Promise<CommunityAnchor[]> {
+  const data = await fetchJSON<CommunityAnchor[]>(`${BASE}/locations/libraries`);
+  return data.map((item) => ({ ...item, type: 'library' as const }));
 }
 
-export function getRecCenters(): Promise<CommunityAnchor[]> {
-  return fetchJSON(`${BASE}/locations/rec-centers`);
+export async function getRecCenters(): Promise<CommunityAnchor[]> {
+  const data = await fetchJSON<CommunityAnchor[]>(`${BASE}/locations/rec-centers`);
+  return data.map((item) => ({ ...item, type: 'rec_center' as const }));
 }
 
 export function getTransitStops(): Promise<TransitStop[]> {


### PR DESCRIPTION
## Summary
- Database rows don't include a `type` field, so `anchor.type` was always `undefined`
- The popup check `anchor.type === 'library'` always failed, falling through to `rec_center` for every marker
- Now `getLibraries()` stamps `type: 'library'` and `getRecCenters()` stamps `type: 'rec_center'` on each row

## Test plan
- [ ] Click a library marker (blue pin) — popup should say "Library"
- [ ] Click a rec center marker (green pin) — popup should say "Rec Center"

🤖 Generated with [Claude Code](https://claude.com/claude-code)