### PR TITLE
Add transit accessibility score per neighborhood

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -7,6 +7,7 @@ import locationsRouter from './routes/locations.js';
 import metricsRouter from './routes/metrics.js';
 import demographicsRouter from './routes/demographics.js';
 import briefRouter from './routes/brief.js';
+import transitRouter from './routes/transit.js';
 
 const app = express();
 const PORT = process.env.PORT || 3001;
@@ -45,6 +46,7 @@ app.use('/api/locations', locationsRouter);
 app.use('/api/311', metricsRouter);
 app.use('/api/demographics', demographicsRouter);
 app.use('/api/brief', briefRouter);
+app.use('/api/transit', transitRouter);
 
 app.listen(PORT, () => {
   logger.info(`Server running on http://localhost:${PORT}`);

--- a/server/routes/transit.ts
+++ b/server/routes/transit.ts
@@ -1,0 +1,162 @@
+import { Router } from 'express';
+import { supabase } from '../services/supabase.js';
+import { logger } from '../logger.js';
+
+const router = Router();
+
+// Cache the computed transit scores for all communities (recompute every 24h)
+const CACHE_TTL = 24 * 60 * 60 * 1000;
+let scoresCache: Map<string, TransitScore> | null = null;
+let scoresCachedAt = 0;
+
+interface TransitScore {
+  stopCount: number;
+  agencyCount: number;
+  agencies: string[];
+  rawScore: number;
+  transitScore: number; // normalized 0-100
+}
+
+// Simple point-in-polygon (ray casting)
+function pointInPolygon(lat: number, lng: number, polygon: number[][]): boolean {
+  let inside = false;
+  for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
+    const [xi, yi] = polygon[i];
+    const [xj, yj] = polygon[j];
+    if ((yi > lat) !== (yj > lat) && lng < ((xj - xi) * (lat - yi)) / (yj - yi) + xi) {
+      inside = !inside;
+    }
+  }
+  return inside;
+}
+
+function pointInFeature(lat: number, lng: number, geometry: { type: string; coordinates: number[][][] | number[][][][] }): boolean {
+  if (geometry.type === 'Polygon') {
+    const coords = geometry.coordinates as number[][][];
+    return pointInPolygon(lat, lng, coords[0]);
+  }
+  if (geometry.type === 'MultiPolygon') {
+    const coords = geometry.coordinates as number[][][][];
+    return coords.some((poly) => pointInPolygon(lat, lng, poly[0]));
+  }
+  return false;
+}
+
+const NEIGHBORHOODS_URL =
+  'https://seshat.datasd.org/gis_community_planning_districts/cmty_plan_datasd.geojson';
+
+async function computeAllScores(): Promise<Map<string, TransitScore>> {
+  // Fetch all transit stops with location and agency data
+  const { data: stops, error } = await supabase
+    .from('transit_stops')
+    .select('lat, lng, stop_agncy');
+
+  if (error) throw new Error(`Failed to fetch transit stops: ${error.message}`);
+
+  // Fetch community boundaries
+  const response = await fetch(NEIGHBORHOODS_URL);
+  if (!response.ok) throw new Error(`Failed to fetch boundaries: ${response.status}`);
+  const geojson = await response.json();
+
+  const scores = new Map<string, TransitScore>();
+
+  // For each community, count stops and unique agencies within its boundary
+  for (const feature of geojson.features) {
+    const communityName: string = feature.properties?.cpname || feature.properties?.name || '';
+    if (!communityName) continue;
+
+    const stopsInCommunity: { stop_agncy: string | null }[] = [];
+    for (const stop of stops) {
+      if (stop.lat == null || stop.lng == null) continue;
+      // GeoJSON coordinates are [lng, lat]
+      if (pointInFeature(stop.lat, stop.lng, feature.geometry)) {
+        stopsInCommunity.push(stop);
+      }
+    }
+
+    const agencies = new Set<string>();
+    for (const s of stopsInCommunity) {
+      if (s.stop_agncy) agencies.add(s.stop_agncy);
+    }
+
+    const stopCount = stopsInCommunity.length;
+    const agencyCount = agencies.size;
+    // Composite: stops * 0.4 + routes(agencies) * 0.6
+    // Agency count is small (typically 1-3), so scale it up to be comparable with stop count
+    const rawScore = stopCount * 0.4 + agencyCount * 10 * 0.6;
+
+    scores.set(communityName.toUpperCase(), {
+      stopCount,
+      agencyCount,
+      agencies: Array.from(agencies),
+      rawScore,
+      transitScore: 0, // will normalize after
+    });
+  }
+
+  // Normalize to 0-100
+  const maxRaw = Math.max(...Array.from(scores.values()).map((s) => s.rawScore), 1);
+  for (const score of scores.values()) {
+    score.transitScore = Math.round((score.rawScore / maxRaw) * 100);
+  }
+
+  return scores;
+}
+
+async function getScores(): Promise<Map<string, TransitScore>> {
+  const now = Date.now();
+  if (scoresCache && now - scoresCachedAt < CACHE_TTL) {
+    return scoresCache;
+  }
+  scoresCache = await computeAllScores();
+  scoresCachedAt = now;
+  return scoresCache;
+}
+
+router.get('/', async (req, res) => {
+  const community = req.query.community as string | undefined;
+  if (!community) {
+    res.status(400).json({ error: 'community query parameter is required' });
+    return;
+  }
+
+  const cleaned = community.replace(/[%_]/g, '');
+  if (cleaned.length > 100 || cleaned.length === 0) {
+    res.status(400).json({ error: 'Invalid community name' });
+    return;
+  }
+
+  try {
+    const scores = await getScores();
+    const key = cleaned.toUpperCase();
+    const score = scores.get(key);
+
+    if (!score) {
+      // Return zeroed score for unknown communities
+      res.json({
+        stopCount: 0,
+        agencyCount: 0,
+        agencies: [],
+        transitScore: 0,
+        cityAverage: getCityAverage(scores),
+      });
+      return;
+    }
+
+    res.json({
+      ...score,
+      cityAverage: getCityAverage(scores),
+    });
+  } catch (err) {
+    logger.error('Failed to compute transit scores', { error: (err as Error).message });
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+function getCityAverage(scores: Map<string, TransitScore>): number {
+  const values = Array.from(scores.values());
+  if (values.length === 0) return 0;
+  return Math.round(values.reduce((sum, s) => sum + s.transitScore, 0) / values.length);
+}
+
+export default router;

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -32,6 +32,10 @@ export function getNeighborhoodBoundaries(): Promise<FeatureCollection> {
   return fetchJSON(`${BASE}/locations/neighborhoods`);
 }
 
+export function getTransitScore(community: string): Promise<NeighborhoodProfile['transit']> {
+  return fetchJSON(`${BASE}/transit?community=${encodeURIComponent(community)}`);
+}
+
 export function get311(community: string): Promise<NeighborhoodProfile['metrics']> {
   return fetchJSON(`${BASE}/311?community=${encodeURIComponent(community)}`);
 }

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -13,6 +13,7 @@ interface SidebarProps {
   briefLoading: boolean;
   briefError: string | null;
   topLanguages?: { language: string; percentage: number }[];
+  transitScore?: NeighborhoodProfile['transit'] | null;
 }
 
 function LoadingSpinner({ label }: { label: string }) {
@@ -67,6 +68,7 @@ export default function Sidebar({
   briefLoading,
   briefError,
   topLanguages,
+  transitScore,
 }: SidebarProps) {
   const [showDetails, setShowDetails] = useState(false);
   const { t, briefLang, setBriefLang } = useLanguage();
@@ -156,9 +158,51 @@ export default function Sidebar({
                     <dd className="font-mono font-medium">{metrics.requestsPer1000Residents}</dd>
                   </div>
                 )}
+                {transitScore && transitScore.stopCount > 0 && (
+                  <>
+                    <div className="flex justify-between">
+                      <dt className="text-gray-500">Transit stops</dt>
+                      <dd className="font-mono font-medium">{transitScore.stopCount}</dd>
+                    </div>
+                    <div className="flex justify-between">
+                      <dt className="text-gray-500">Transit score</dt>
+                      <dd className="font-mono font-medium">{transitScore.transitScore}/100</dd>
+                    </div>
+                  </>
+                )}
               </dl>
             )}
           </section>
+
+          {/* Transit accessibility */}
+          {transitScore && transitScore.stopCount > 0 && (
+            <section aria-labelledby="transit-heading" className="rounded-lg bg-indigo-50 border border-indigo-200 p-3">
+              <h2 id="transit-heading" className="text-sm font-medium text-indigo-800 mb-2">
+                Transit Access
+              </h2>
+              <div className="flex items-center gap-3 mb-2">
+                <div className="text-2xl font-bold text-indigo-700">{transitScore.transitScore}</div>
+                <div className="text-xs text-indigo-600">
+                  <span className="block">/ 100</span>
+                  <span className="block">
+                    {transitScore.transitScore > transitScore.cityAverage
+                      ? 'Above city average'
+                      : transitScore.transitScore === transitScore.cityAverage
+                        ? 'At city average'
+                        : 'Below city average'}
+                    {' '}({transitScore.cityAverage})
+                  </span>
+                </div>
+              </div>
+              <p className="text-sm text-indigo-700">
+                Your neighborhood has <span className="font-semibold">{transitScore.stopCount}</span> transit stop{transitScore.stopCount !== 1 ? 's' : ''} served
+                by <span className="font-semibold">{transitScore.agencyCount}</span> transit agenc{transitScore.agencyCount !== 1 ? 'ies' : 'y'}
+                {transitScore.agencies.length > 0 && (
+                  <> ({transitScore.agencies.join(', ')})</>
+                )}.
+              </p>
+            </section>
+          )}
 
           {/* Good news */}
           {metrics.goodNews.length > 0 && (

--- a/src/pages/neighborhood-page.tsx
+++ b/src/pages/neighborhood-page.tsx
@@ -3,7 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import SanDiegoMap from '../components/map/san-diego-map';
 import NeighborhoodSelector from '../components/ui/neighborhood-selector';
 import Sidebar from '../components/ui/sidebar';
-import { getLibraries, getRecCenters, getTransitStops, get311, getDemographics, generateBrief, getNeighborhoodBoundaries } from '../api/client';
+import { getLibraries, getRecCenters, getTransitStops, get311, getDemographics, generateBrief, getNeighborhoodBoundaries, getTransitScore } from '../api/client';
 import type { CommunityAnchor, CommunityBrief, NeighborhoodProfile, TransitStop } from '../types';
 import type { FeatureCollection } from 'geojson';
 import { useLanguage } from '../i18n/context';
@@ -29,6 +29,7 @@ export default function NeighborhoodPage() {
   const [metricsLoading, setMetricsLoading] = useState(false);
   const [topLanguages, setTopLanguages] = useState<{ language: string; percentage: number }[]>([]);
 
+  const [transitScore, setTransitScore] = useState<NeighborhoodProfile['transit'] | null>(null);
   const [dataError, setDataError] = useState<string | null>(null);
 
   const [brief, setBrief] = useState<CommunityBrief | null>(null);
@@ -60,6 +61,7 @@ export default function NeighborhoodPage() {
       setMetrics(null);
       setBrief(null);
       setTopLanguages([]);
+      setTransitScore(null);
       return;
     }
 
@@ -67,11 +69,16 @@ export default function NeighborhoodPage() {
     setMetrics(null);
     setBrief(null);
     setTopLanguages([]);
+    setTransitScore(null);
 
     get311(selectedCommunity)
       .then(setMetrics)
       .catch(console.error)
       .finally(() => setMetricsLoading(false));
+
+    getTransitScore(selectedCommunity)
+      .then(setTransitScore)
+      .catch(() => { /* transit score may not be available */ });
 
     // Try to fetch demographics for language suggestion
     getDemographics(selectedCommunity)
@@ -122,7 +129,7 @@ export default function NeighborhoodPage() {
       communityName: selectedCommunity,
       anchor,
       metrics,
-      transit: { nearbyStopCount: 0, nearestStopDistance: 0 },
+      transit: transitScore ?? { nearbyStopCount: 0, nearestStopDistance: 0, stopCount: 0, agencyCount: 0, agencies: [], transitScore: 0, cityAverage: 0 },
       demographics: { topLanguages },
     };
 
@@ -137,7 +144,7 @@ export default function NeighborhoodPage() {
     } finally {
       setBriefLoading(false);
     }
-  }, [selectedCommunity, selectedAnchor, metrics, topLanguages]);
+  }, [selectedCommunity, selectedAnchor, metrics, topLanguages, transitScore]);
 
   return (
     <div className="flex flex-col h-full md:flex-row print:block">
@@ -191,6 +198,7 @@ export default function NeighborhoodPage() {
             briefLoading={briefLoading}
             briefError={briefError}
             topLanguages={topLanguages}
+            transitScore={transitScore}
           />
         </div>
       </aside>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -27,6 +27,11 @@ export interface NeighborhoodProfile {
   transit: {
     nearbyStopCount: number;
     nearestStopDistance: number;
+    stopCount: number;
+    agencyCount: number;
+    agencies: string[];
+    transitScore: number;
+    cityAverage: number;
   };
   demographics: {
     topLanguages: { language: string; percentage: number }[];


### PR DESCRIPTION
## Summary
- New `/api/transit?community={name}` endpoint that computes a transit accessibility score (0–100) per community using point-in-polygon assignment of transit stops to community boundaries
- Score uses composite formula: `(stopCount × 0.4) + (agencyCount × 10 × 0.6)` normalized across all communities, weighting route diversity over raw stop count
- Sidebar displays transit score with city average comparison and narrative ("Your neighborhood has X transit stops served by Y agencies")
- Results cached 24h; transit stats also shown in progressive disclosure details panel

Closes #18

## Test plan
- [ ] Select a neighborhood (e.g., Mira Mesa) and verify transit score card appears in sidebar
- [ ] Verify score shows stop count, agency count, and agencies list
- [ ] Verify "above/below city average" comparison displays correctly
- [ ] Check that details panel shows transit stops and transit score rows
- [ ] Test with a community that has no transit stops — card should not appear
- [ ] Verify no TypeScript errors (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)