### PR TITLE
Add street-level block report on map click

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -9,6 +9,7 @@ import demographicsRouter from './routes/demographics.js';
 import briefRouter from './routes/brief.js';
 import transitRouter from './routes/transit.js';
 import gapAnalysisRouter from './routes/gap-analysis.js';
+import blockRouter from './routes/block.js';
 
 const app = express();
 const PORT = process.env.PORT || 3001;
@@ -49,6 +50,7 @@ app.use('/api/demographics', demographicsRouter);
 app.use('/api/brief', briefRouter);
 app.use('/api/transit', transitRouter);
 app.use('/api/access-gap', gapAnalysisRouter);
+app.use('/api/block', blockRouter);
 
 app.listen(PORT, () => {
   logger.info(`Server running on http://localhost:${PORT}`);

--- a/server/routes/block.ts
+++ b/server/routes/block.ts
@@ -1,0 +1,94 @@
+import { Router } from 'express';
+import { supabase } from '../services/supabase.js';
+import { logger } from '../logger.js';
+
+const router = Router();
+
+// 1 degree of latitude ~ 69 miles; longitude varies by latitude
+const MILES_PER_LAT_DEG = 69;
+// At San Diego (~32.7°N): 1 deg longitude ~ 58.8 miles
+const MILES_PER_LNG_DEG = 58.8;
+
+function haversineDistanceMiles(lat1: number, lng1: number, lat2: number, lng2: number): number {
+  const R = 3958.8;
+  const toRad = (d: number) => (d * Math.PI) / 180;
+  const dLat = toRad(lat2 - lat1);
+  const dLng = toRad(lng2 - lng1);
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLng / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+router.get('/', async (req, res) => {
+  const lat = parseFloat(req.query.lat as string);
+  const lng = parseFloat(req.query.lng as string);
+  const radius = parseFloat(req.query.radius as string) || 0.25;
+
+  if (isNaN(lat) || isNaN(lng)) {
+    res.status(400).json({ error: 'lat and lng query parameters are required' });
+    return;
+  }
+
+  // Rough San Diego bounding box check
+  if (lat < 32.5 || lat > 33.2 || lng < -117.6 || lng > -116.8) {
+    res.status(400).json({ error: 'Coordinates are outside the San Diego area' });
+    return;
+  }
+
+  if (radius < 0.1 || radius > 2) {
+    res.status(400).json({ error: 'Radius must be between 0.1 and 2 miles' });
+    return;
+  }
+
+  const latDelta = radius / MILES_PER_LAT_DEG;
+  const lngDelta = radius / MILES_PER_LNG_DEG;
+
+  const { data, error } = await supabase
+    .from('requests_311')
+    .select('service_name, status, date_requested, date_closed, lat, lng')
+    .gte('lat', lat - latDelta)
+    .lte('lat', lat + latDelta)
+    .gte('lng', lng - lngDelta)
+    .lte('lng', lng + lngDelta);
+
+  if (error) {
+    logger.error('Failed to fetch block data', { error: error.message });
+    res.status(500).json({ error: 'Internal server error' });
+    return;
+  }
+
+  // Refine with exact Haversine distance
+  const nearby = (data ?? []).filter(
+    (r) => r.lat != null && r.lng != null &&
+      haversineDistanceMiles(lat, lng, Number(r.lat), Number(r.lng)) <= radius,
+  );
+
+  const open = nearby.filter((r) => r.status !== 'Closed' && !r.date_closed);
+  const resolved = nearby.filter((r) => r.status === 'Closed' || r.date_closed);
+
+  const issueCounts: Record<string, number> = {};
+  for (const r of nearby) {
+    const cat = r.service_name || 'Unknown';
+    issueCounts[cat] = (issueCounts[cat] || 0) + 1;
+  }
+  const topCategory =
+    Object.entries(issueCounts).sort(([, a], [, b]) => b - a)[0]?.[0] ?? null;
+
+  const recentlyResolved = resolved
+    .filter((r) => r.date_closed)
+    .sort((a, b) => new Date(b.date_closed).getTime() - new Date(a.date_closed).getTime())
+    .slice(0, 3)
+    .map((r) => ({ category: r.service_name || 'Unknown', date: r.date_closed as string }));
+
+  res.json({
+    totalRequests: nearby.length,
+    openCount: open.length,
+    resolvedCount: resolved.length,
+    topCategory,
+    recentlyResolved,
+    radiusMiles: radius,
+  });
+});
+
+export default router;

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,5 +1,5 @@
 import type { FeatureCollection } from 'geojson';
-import type { CommunityAnchor, CommunityBrief, NeighborhoodProfile, TransitStop } from '../types';
+import type { BlockMetrics, CommunityAnchor, CommunityBrief, NeighborhoodProfile, TransitStop } from '../types';
 
 const BASE = '/api';
 
@@ -52,6 +52,10 @@ export function getAccessGapRanking(limit = 10): Promise<{
   ranking: { community: string; accessGapScore: number; signals: NonNullable<NeighborhoodProfile['accessGap']>['signals'] }[];
 }> {
   return fetchJSON(`${BASE}/access-gap/ranking?limit=${limit}`);
+}
+
+export function getBlockData(lat: number, lng: number, radius = 0.25): Promise<BlockMetrics> {
+  return fetchJSON(`${BASE}/block?lat=${lat}&lng=${lng}&radius=${radius}`);
 }
 
 export function generateBrief(profile: NeighborhoodProfile, language: string): Promise<CommunityBrief> {

--- a/src/components/map/san-diego-map.tsx
+++ b/src/components/map/san-diego-map.tsx
@@ -1,11 +1,11 @@
-import { memo, useCallback, useEffect } from 'react';
-import { MapContainer, TileLayer, Marker, Popup, CircleMarker, GeoJSON, useMap } from 'react-leaflet';
+import { memo, useCallback, useEffect, useRef } from 'react';
+import { MapContainer, TileLayer, Marker, Popup, CircleMarker, GeoJSON, useMap, useMapEvents } from 'react-leaflet';
 import L from 'leaflet';
 import iconUrl from 'leaflet/dist/images/marker-icon.png';
 import iconRetinaUrl from 'leaflet/dist/images/marker-icon-2x.png';
 import shadowUrl from 'leaflet/dist/images/marker-shadow.png';
 import type { Feature, FeatureCollection } from 'geojson';
-import type { CommunityAnchor, TransitStop } from '../../types';
+import type { BlockMetrics, CommunityAnchor, TransitStop } from '../../types';
 
 // ── Popup content components ─────────────────────────────────────────────────
 
@@ -85,6 +85,79 @@ function TransitPopupContent({ name }: { name: string }) {
   );
 }
 
+function BlockPopupContent({
+  loading,
+  data,
+}: {
+  loading: boolean;
+  data: BlockMetrics | null;
+}) {
+  if (loading) {
+    return (
+      <div className="min-w-[200px] flex items-center gap-2 py-2">
+        <div className="h-4 w-4 animate-spin rounded-full border-2 border-gray-300 border-t-orange-500 shrink-0" />
+        <span className="text-sm text-gray-600">Loading block data…</span>
+      </div>
+    );
+  }
+  if (!data) {
+    return (
+      <div className="min-w-[200px] text-sm text-gray-500 py-1">No data available.</div>
+    );
+  }
+  return (
+    <div className="min-w-[220px] max-w-[280px]">
+      <div className="flex items-center gap-1.5 mb-2">
+        <span aria-hidden="true" className="w-2.5 h-2.5 rounded-full shrink-0 bg-orange-500" />
+        <span className="text-xs font-semibold uppercase tracking-wide text-orange-700">
+          Your Block · {data.radiusMiles} mi radius
+        </span>
+      </div>
+      <div className="flex gap-3 mb-3">
+        <div className="text-center">
+          <p className="text-xl font-bold text-gray-900">{data.openCount}</p>
+          <p className="text-xs text-gray-500">open</p>
+        </div>
+        <div className="text-center">
+          <p className="text-xl font-bold text-gray-900">{data.resolvedCount}</p>
+          <p className="text-xs text-gray-500">resolved</p>
+        </div>
+        <div className="text-center">
+          <p className="text-xl font-bold text-gray-900">{data.totalRequests}</p>
+          <p className="text-xs text-gray-500">total</p>
+        </div>
+      </div>
+      {data.topCategory && (
+        <p className="text-xs text-gray-700 mb-2">
+          <span className="font-medium">Top issue:</span> {data.topCategory}
+        </p>
+      )}
+      {data.recentlyResolved.length > 0 && (
+        <div className="mb-2">
+          <p className="text-xs font-medium text-gray-700 mb-1">Recently resolved</p>
+          <ul className="space-y-0.5">
+            {data.recentlyResolved.map((r, i) => (
+              <li key={`${r.category}-${r.date}-${i}`} className="text-xs text-gray-600 flex justify-between gap-2">
+                <span className="truncate">{r.category}</span>
+                <span className="shrink-0 text-gray-400">
+                  {new Date(r.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      <button
+        type="button"
+        onClick={() => window.print()}
+        className="w-full mt-1 rounded bg-orange-500 px-3 py-1.5 text-xs font-medium text-white hover:bg-orange-600"
+      >
+        Print brief for this area
+      </button>
+    </div>
+  );
+}
+
 // Fix Leaflet default icon paths for bundlers
 L.Icon.Default.mergeOptions({ iconUrl, iconRetinaUrl, shadowUrl });
 
@@ -106,6 +179,7 @@ function makePinIcon(color: string) {
 
 const blueIcon = makePinIcon('#3b82f6');
 const greenIcon = makePinIcon('#22c55e');
+const orangeIcon = makePinIcon('#f97316');
 
 interface SanDiegoMapProps {
   libraries: CommunityAnchor[];
@@ -114,6 +188,10 @@ interface SanDiegoMapProps {
   neighborhoodBoundaries: FeatureCollection | null;
   selectedCommunity: string | null;
   onAnchorClick: (anchor: CommunityAnchor) => void;
+  onMapClick?: (lat: number, lng: number) => void;
+  pinnedLocation?: { lat: number; lng: number } | null;
+  blockData?: BlockMetrics | null;
+  blockLoading?: boolean;
 }
 
 // Normalize strings for fuzzy matching (e.g. "City Heights" matches "Mid-City:City Heights")
@@ -129,6 +207,51 @@ function findCommunityFeature(features: Feature[], community: string): Feature |
     features.find((f) => target.includes(norm(f.properties?.cpname ?? ''))) ??
     null
   );
+}
+
+// Child component — pinned block location marker that auto-opens its popup
+function PinnedMarker({
+  lat,
+  lng,
+  loading,
+  data,
+}: {
+  lat: number;
+  lng: number;
+  loading: boolean;
+  data: BlockMetrics | null;
+}) {
+  const markerRef = useRef<L.Marker | null>(null);
+  useEffect(() => {
+    markerRef.current?.openPopup();
+  }, [lat, lng]);
+  return (
+    <Marker
+      position={[lat, lng]}
+      icon={orangeIcon}
+      title="Your block"
+      alt="Pinned location"
+      ref={markerRef}
+    >
+      <Popup>
+        <BlockPopupContent loading={loading} data={data} />
+      </Popup>
+    </Marker>
+  );
+}
+
+// Child component — handles map click events with debounce
+function MapClickHandler({ onClick }: { onClick: (lat: number, lng: number) => void }) {
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useMapEvents({
+    click(e) {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(() => {
+        onClick(e.latlng.lat, e.latlng.lng);
+      }, 300);
+    },
+  });
+  return null;
 }
 
 // Child component — uses useMap() to zoom to selected community bounds
@@ -152,6 +275,10 @@ function SanDiegoMap({
   neighborhoodBoundaries,
   selectedCommunity,
   onAnchorClick,
+  onMapClick,
+  pinnedLocation,
+  blockData,
+  blockLoading = false,
 }: SanDiegoMapProps) {
   const handleMarkerClick = useCallback(
     (anchor: CommunityAnchor) => () => {
@@ -181,6 +308,10 @@ function SanDiegoMap({
           <span aria-hidden="true" className="inline-block w-3 h-3 rounded-full bg-gray-400 shrink-0" />
           <span className="text-gray-700">Transit Stop</span>
         </li>
+        <li className="flex items-center gap-2">
+          <span aria-hidden="true" className="inline-block w-3 h-3 rounded-full bg-orange-500 shrink-0" />
+          <span className="text-gray-700">Your Block</span>
+        </li>
       </ul>
     </nav>
     <MapContainer
@@ -193,6 +324,19 @@ function SanDiegoMap({
         attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
         url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
       />
+
+      {/* Click-to-explore handler */}
+      {onMapClick && <MapClickHandler onClick={onMapClick} />}
+
+      {/* Pinned location marker — auto-opens popup when dropped */}
+      {pinnedLocation && (
+        <PinnedMarker
+          lat={pinnedLocation.lat}
+          lng={pinnedLocation.lng}
+          loading={blockLoading}
+          data={blockData ?? null}
+        />
+      )}
 
       {/* Zoom to selected community + highlight its boundary */}
       <MapController feature={selectedFeature} />

--- a/src/pages/neighborhood-page.tsx
+++ b/src/pages/neighborhood-page.tsx
@@ -3,8 +3,8 @@ import { useParams, useNavigate } from 'react-router-dom';
 import SanDiegoMap from '../components/map/san-diego-map';
 import NeighborhoodSelector from '../components/ui/neighborhood-selector';
 import Sidebar from '../components/ui/sidebar';
-import { getLibraries, getRecCenters, getTransitStops, get311, getDemographics, generateBrief, getNeighborhoodBoundaries, getTransitScore, getAccessGap } from '../api/client';
-import type { CommunityAnchor, CommunityBrief, NeighborhoodProfile, TransitStop } from '../types';
+import { getLibraries, getRecCenters, getTransitStops, get311, getDemographics, generateBrief, getNeighborhoodBoundaries, getTransitScore, getAccessGap, getBlockData } from '../api/client';
+import type { BlockMetrics, CommunityAnchor, CommunityBrief, NeighborhoodProfile, TransitStop } from '../types';
 import type { FeatureCollection } from 'geojson';
 import { useLanguage } from '../i18n/context';
 import { SUPPORTED_LANGUAGES } from '../i18n/translations';
@@ -31,6 +31,10 @@ export default function NeighborhoodPage() {
 
   const [transitScore, setTransitScore] = useState<NeighborhoodProfile['transit'] | null>(null);
   const [accessGap, setAccessGap] = useState<NeighborhoodProfile['accessGap']>(null);
+  const [pinnedLocation, setPinnedLocation] = useState<{ lat: number; lng: number } | null>(null);
+  const [blockData, setBlockData] = useState<BlockMetrics | null>(null);
+  const [blockLoading, setBlockLoading] = useState(false);
+
   const [dataError, setDataError] = useState<string | null>(null);
 
   const [brief, setBrief] = useState<CommunityBrief | null>(null);
@@ -118,6 +122,20 @@ export default function NeighborhoodPage() {
     },
     [navigate],
   );
+
+  const handleMapClick = useCallback(async (lat: number, lng: number) => {
+    setPinnedLocation({ lat, lng });
+    setBlockData(null);
+    setBlockLoading(true);
+    try {
+      const data = await getBlockData(lat, lng);
+      setBlockData(data);
+    } catch (err) {
+      console.error('Failed to fetch block data', err);
+    } finally {
+      setBlockLoading(false);
+    }
+  }, []);
 
   const handleGenerateBrief = useCallback(async (language: string) => {
     if (!selectedCommunity || !metrics) return;
@@ -228,6 +246,10 @@ export default function NeighborhoodPage() {
           neighborhoodBoundaries={neighborhoodBoundaries}
           selectedCommunity={selectedCommunity}
           onAnchorClick={(anchor) => { handleAnchorClick(anchor); setMobileView('info'); }}
+          onMapClick={handleMapClick}
+          pinnedLocation={pinnedLocation}
+          blockData={blockData}
+          blockLoading={blockLoading}
         />
       </main>
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -55,6 +55,15 @@ export interface TransitStop {
   lng: number;
 }
 
+export interface BlockMetrics {
+  totalRequests: number;
+  openCount: number;
+  resolvedCount: number;
+  topCategory: string | null;
+  recentlyResolved: { category: string; date: string }[];
+  radiusMiles: number;
+}
+
 export interface CommunityBrief {
   neighborhoodName: string;
   language: string;


### PR DESCRIPTION
## Summary
- New `/api/block` endpoint: radius-based 311 query using bounding box + Haversine distance
- `MapClickHandler` with 300ms debounce using `useMapEvents`
- `PinnedMarker` component that auto-opens a popup with loading state
- Block popup shows open/resolved counts, top issue category, recently resolved cases, and print button
- `BlockMetrics` type and `getBlockData` client function

## Test plan
- [ ] Click anywhere on the map to drop an orange pin
- [ ] Popup auto-opens with loading spinner, then shows block data
- [ ] Stats show open, resolved, total counts within 0.25 miles
- [ ] Top issue category and recently resolved cases display correctly
- [ ] "Print brief for this area" button triggers print
- [ ] Works on both desktop and mobile

Fixes #29