### PR TITLE
Fix print functionality for clean one-page output

### DIFF
--- a/src/components/brief/brief-display.tsx
+++ b/src/components/brief/brief-display.tsx
@@ -52,91 +52,93 @@ export default function BriefDisplay({ brief, loading }: BriefDisplayProps) {
   });
 
   return (
-    <div className="brief-content bg-white rounded-lg shadow p-6 max-w-2xl mx-auto">
-      {/* Header */}
-      <div className="border-b border-gray-200 pb-4 mb-4">
-        <h2 className="text-2xl font-bold text-gray-900">
-          {brief.neighborhoodName}
-        </h2>
-        <p className="text-sm text-gray-500 mt-1">
-          {t('brief.communityBrief')} &middot; {formattedDate} &middot; {brief.language}
-        </p>
+    <>
+      <div className="brief-content bg-white rounded-lg shadow p-6 max-w-2xl mx-auto">
+        {/* Header */}
+        <div className="border-b border-gray-200 pb-4 mb-4">
+          <h2 className="text-2xl font-bold text-gray-900">
+            {brief.neighborhoodName}
+          </h2>
+          <p className="text-sm text-gray-500 mt-1">
+            {t('brief.communityBrief')} &middot; {formattedDate} &middot; {brief.language}
+          </p>
+        </div>
+
+        {/* Welcome / Summary */}
+        <section className="mb-5">
+          <p className="text-gray-700 leading-relaxed">{brief.summary}</p>
+        </section>
+
+        {/* Good News */}
+        <section className="mb-5">
+          <h3 className="text-lg font-semibold text-green-700 mb-2">{t('brief.goodNews')}</h3>
+          <ul className="list-disc list-inside space-y-1 text-gray-700">
+            {brief.goodNews.map((item, i) => (
+              <li key={i}>{item}</li>
+            ))}
+          </ul>
+        </section>
+
+        {/* Top Issues */}
+        <section className="mb-5">
+          <h3 className="text-lg font-semibold text-amber-700 mb-2">
+            {t('brief.topIssues')}
+          </h3>
+          <ul className="list-disc list-inside space-y-1 text-gray-700">
+            {brief.topIssues.map((item, i) => (
+              <li key={i}>{item}</li>
+            ))}
+          </ul>
+        </section>
+
+        {/* How to Participate */}
+        <section className="mb-5">
+          <h3 className="text-lg font-semibold text-blue-700 mb-2">
+            {t('brief.howTo')}
+          </h3>
+          <ul className="list-disc list-inside space-y-1 text-gray-700">
+            {brief.howToParticipate.map((item, i) => (
+              <li key={i}>{item}</li>
+            ))}
+          </ul>
+        </section>
+
+        {/* Contact Info */}
+        <section className="mb-5 bg-gray-50 rounded-md p-4">
+          <h3 className="text-lg font-semibold text-gray-800 mb-2">{t('brief.contactInfo')}</h3>
+          <dl className="space-y-1 text-sm text-gray-700">
+            <div className="flex gap-2">
+              <dt className="font-medium">{t('brief.councilDistrict')}</dt>
+              <dd>{brief.contactInfo.councilDistrict}</dd>
+            </div>
+            <div className="flex gap-2">
+              <dt className="font-medium">{t('brief.phone311')}</dt>
+              <dd>{brief.contactInfo.phone311}</dd>
+            </div>
+            <div className="flex gap-2">
+              <dt className="font-medium">{t('brief.nearestResource')}</dt>
+              <dd>{brief.contactInfo.anchorLocation}</dd>
+            </div>
+          </dl>
+        </section>
+
+        {/* Print button */}
+        <div className="no-print mt-4 text-center">
+          <button
+            type="button"
+            onClick={() => window.print()}
+            className="px-5 py-2 bg-blue-600 text-white rounded-md text-sm font-medium hover:bg-blue-700 transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
+          >
+            {t('brief.print')}
+          </button>
+        </div>
       </div>
 
-      {/* Welcome / Summary */}
-      <section className="mb-5">
-        <p className="text-gray-700 leading-relaxed">{brief.summary}</p>
-      </section>
-
-      {/* Good News */}
-      <section className="mb-5">
-        <h3 className="text-lg font-semibold text-green-700 mb-2">{t('brief.goodNews')}</h3>
-        <ul className="list-disc list-inside space-y-1 text-gray-700">
-          {brief.goodNews.map((item, i) => (
-            <li key={i}>{item}</li>
-          ))}
-        </ul>
-      </section>
-
-      {/* Top Issues */}
-      <section className="mb-5">
-        <h3 className="text-lg font-semibold text-amber-700 mb-2">
-          {t('brief.topIssues')}
-        </h3>
-        <ul className="list-disc list-inside space-y-1 text-gray-700">
-          {brief.topIssues.map((item, i) => (
-            <li key={i}>{item}</li>
-          ))}
-        </ul>
-      </section>
-
-      {/* How to Participate */}
-      <section className="mb-5">
-        <h3 className="text-lg font-semibold text-blue-700 mb-2">
-          {t('brief.howTo')}
-        </h3>
-        <ul className="list-disc list-inside space-y-1 text-gray-700">
-          {brief.howToParticipate.map((item, i) => (
-            <li key={i}>{item}</li>
-          ))}
-        </ul>
-      </section>
-
-      {/* Contact Info */}
-      <section className="mb-5 bg-gray-50 rounded-md p-4">
-        <h3 className="text-lg font-semibold text-gray-800 mb-2">{t('brief.contactInfo')}</h3>
-        <dl className="space-y-1 text-sm text-gray-700">
-          <div className="flex gap-2">
-            <dt className="font-medium">{t('brief.councilDistrict')}</dt>
-            <dd>{brief.contactInfo.councilDistrict}</dd>
-          </div>
-          <div className="flex gap-2">
-            <dt className="font-medium">{t('brief.phone311')}</dt>
-            <dd>{brief.contactInfo.phone311}</dd>
-          </div>
-          <div className="flex gap-2">
-            <dt className="font-medium">{t('brief.nearestResource')}</dt>
-            <dd>{brief.contactInfo.anchorLocation}</dd>
-          </div>
-        </dl>
-      </section>
-
-      {/* Print button */}
-      <div className="no-print mt-4 text-center">
-        <button
-          type="button"
-          onClick={() => window.print()}
-          className="px-5 py-2 bg-blue-600 text-white rounded-md text-sm font-medium hover:bg-blue-700 transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
-        >
-          {t('brief.print')}
-        </button>
-      </div>
-
-      {/* Flyer layout — hidden on screen, shown when printing */}
+      {/* Flyer layout — OUTSIDE .brief-content so print.css can show it */}
       <BriefFlyer
         brief={brief}
         neighborhoodSlug={toSlug(brief.neighborhoodName)}
       />
-    </div>
+    </>
   );
 }

--- a/src/print.css
+++ b/src/print.css
@@ -5,15 +5,24 @@
     margin: 0.5in;
   }
 
+  /* Reset layout constraints for print */
+  html, body, #root {
+    height: auto !important;
+    overflow: visible !important;
+  }
+
+  /* Hide everything visually (but keep in flow so children can override) */
   body * {
     visibility: hidden;
   }
 
+  /* Show the flyer and all its children */
   .brief-flyer,
   .brief-flyer * {
     visibility: visible;
   }
 
+  /* Position flyer at top-left, full width */
   .brief-flyer {
     position: absolute;
     left: 0;
@@ -21,14 +30,16 @@
     width: 100%;
   }
 
-  /* Hide screen-only elements */
+  /* Fully hide elements that should not occupy space at all */
   .no-print,
   .brief-content,
-  nav[aria-label="Main navigation"] {
+  nav[aria-label="Main navigation"],
+  main[aria-label="Neighborhood map"],
+  [role="tablist"] {
     display: none !important;
   }
 
-  /* Keep sections together */
+  /* Keep sections together across page breaks */
   .flyer-section {
     break-inside: avoid;
   }


### PR DESCRIPTION
## Summary
- **Root cause:** `BriefFlyer` was rendered inside `.brief-content`, which `print.css` hides with `display: none !important` — making the flyer always invisible during print
- Moved `<BriefFlyer>` outside `.brief-content` using a React fragment so print CSS can show it independently
- Added `#root` to overflow/height resets in print stylesheet for clean page rendering

Closes #41

## Test plan
- [ ] Select a neighborhood (e.g. Mira Mesa) and generate a brief
- [ ] Click the "Print Brief" button — verify Chrome print preview shows only the flyer content
- [ ] Verify no app chrome (nav, map, buttons, tabs) appears in the printout
- [ ] Verify the output fits on one US Letter page (portrait)
- [ ] Verify text is readable (11pt+ minimum)
- [ ] Verify Ctrl+P produces the same clean output

🤖 Generated with [Claude Code](https://claude.com/claude-code)