### PR TITLE
Add composite access gap score for underserved neighborhoods (#19)

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -8,6 +8,7 @@ import metricsRouter from './routes/metrics.js';
 import demographicsRouter from './routes/demographics.js';
 import briefRouter from './routes/brief.js';
 import transitRouter from './routes/transit.js';
+import gapAnalysisRouter from './routes/gap-analysis.js';
 
 const app = express();
 const PORT = process.env.PORT || 3001;
@@ -47,6 +48,7 @@ app.use('/api/311', metricsRouter);
 app.use('/api/demographics', demographicsRouter);
 app.use('/api/brief', briefRouter);
 app.use('/api/transit', transitRouter);
+app.use('/api/access-gap', gapAnalysisRouter);
 
 app.listen(PORT, () => {
   logger.info(`Server running on http://localhost:${PORT}`);

--- a/server/routes/gap-analysis.ts
+++ b/server/routes/gap-analysis.ts
@@ -1,0 +1,54 @@
+import { Router } from 'express';
+import { getAccessGapScore, getTopUnderserved } from '../services/gap-analysis.js';
+import { logger } from '../logger.js';
+
+const router = Router();
+
+// GET /api/access-gap?community={name}
+router.get('/', async (req, res) => {
+  const community = req.query.community as string | undefined;
+  if (!community) {
+    res.status(400).json({ error: 'community query parameter is required' });
+    return;
+  }
+
+  const cleaned = community.replace(/[%_]/g, '');
+  if (cleaned.length > 100 || cleaned.length === 0) {
+    res.status(400).json({ error: 'Invalid community name' });
+    return;
+  }
+
+  try {
+    const result = await getAccessGapScore(cleaned);
+
+    if (!result) {
+      res.json({
+        accessGapScore: null,
+        signals: { lowEngagement: null, lowTransit: null, highNonEnglish: null },
+        rank: null,
+        totalCommunities: 0,
+      });
+      return;
+    }
+
+    res.json(result);
+  } catch (err) {
+    logger.error('Failed to compute access gap score', { error: (err as Error).message });
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// GET /api/access-gap/ranking?limit={n}
+router.get('/ranking', async (_req, res) => {
+  const limit = Math.min(Number(_req.query.limit) || 10, 50);
+
+  try {
+    const ranking = await getTopUnderserved(limit);
+    res.json({ ranking });
+  } catch (err) {
+    logger.error('Failed to compute access gap ranking', { error: (err as Error).message });
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+export default router;

--- a/server/services/gap-analysis.ts
+++ b/server/services/gap-analysis.ts
@@ -1,0 +1,316 @@
+import { supabase } from './supabase.js';
+import { logger } from '../logger.js';
+
+export interface AccessGapResult {
+  accessGapScore: number;
+  signals: {
+    lowEngagement: number | null;
+    lowTransit: number | null;
+    highNonEnglish: number | null;
+  };
+  rank: number;
+  totalCommunities: number;
+}
+
+interface CommunityRawData {
+  engagementRate: number | null; // requests per 1,000 residents
+  transitScore: number | null;  // 0-100
+  nonEnglishPct: number | null; // 0-1
+}
+
+const CACHE_TTL = 24 * 60 * 60 * 1000;
+let scoresCache: Map<string, AccessGapResult> | null = null;
+let scoresCachedAt = 0;
+
+// Min-max normalize a value to 0-1. Returns null if bounds are equal.
+function normalize(value: number, min: number, max: number): number {
+  if (max === min) return 0;
+  return Math.max(0, Math.min(1, (value - min) / (max - min)));
+}
+
+// Fetch 311 engagement rates for all communities from the requests_311 table
+async function fetchEngagementRates(): Promise<Map<string, number>> {
+  const { data: requests, error: reqErr } = await supabase
+    .from('requests_311')
+    .select('comm_plan_name');
+
+  if (reqErr) throw new Error(`Failed to fetch 311 data: ${reqErr.message}`);
+
+  // Count requests per community (normalize names to uppercase)
+  const counts = new Map<string, number>();
+  for (const r of requests) {
+    if (!r.comm_plan_name) continue;
+    const key = r.comm_plan_name.toUpperCase().trim();
+    counts.set(key, (counts.get(key) || 0) + 1);
+  }
+
+  // Fetch population per community from census data
+  const { data: censusRows, error: censusErr } = await supabase
+    .from('census_language')
+    .select('community, total_pop_5plus');
+
+  if (censusErr) throw new Error(`Failed to fetch census data: ${censusErr.message}`);
+
+  const populations = new Map<string, number>();
+  for (const row of censusRows) {
+    if (!row.community) continue;
+    const key = row.community.toUpperCase().trim();
+    populations.set(key, (populations.get(key) || 0) + (Number(row.total_pop_5plus) || 0));
+  }
+
+  // Compute per-1000 rate for communities that have both data points
+  const rates = new Map<string, number>();
+  for (const [community, pop] of populations) {
+    if (pop <= 0) continue;
+    const reqCount = counts.get(community) || 0;
+    rates.set(community, (reqCount / pop) * 1000);
+  }
+
+  return rates;
+}
+
+// Fetch transit scores for all communities
+async function fetchTransitScores(): Promise<Map<string, number>> {
+  const { data: stops, error } = await supabase
+    .from('transit_stops')
+    .select('lat, lng, stop_agncy');
+
+  if (error) throw new Error(`Failed to fetch transit stops: ${error.message}`);
+
+  const boundaryRes = await fetch(
+    'https://seshat.datasd.org/gis_community_planning_districts/cmty_plan_datasd.geojson'
+  );
+  if (!boundaryRes.ok) throw new Error(`Failed to fetch boundaries: ${boundaryRes.status}`);
+  const geojson = await boundaryRes.json();
+
+  const scores = new Map<string, number>();
+
+  for (const feature of geojson.features) {
+    const name: string = feature.properties?.cpname || feature.properties?.name || '';
+    if (!name) continue;
+
+    let stopCount = 0;
+    const agencies = new Set<string>();
+
+    for (const stop of stops) {
+      if (stop.lat == null || stop.lng == null) continue;
+      if (pointInFeature(stop.lat, stop.lng, feature.geometry)) {
+        stopCount++;
+        if (stop.stop_agncy) agencies.add(stop.stop_agncy);
+      }
+    }
+
+    const rawScore = stopCount * 0.4 + agencies.size * 10 * 0.6;
+    scores.set(name.toUpperCase(), rawScore);
+  }
+
+  // Normalize to 0-100
+  const maxRaw = Math.max(...Array.from(scores.values()), 1);
+  for (const [key, raw] of scores) {
+    scores.set(key, Math.round((raw / maxRaw) * 100));
+  }
+
+  return scores;
+}
+
+// Fetch non-English speaking percentage per community
+async function fetchNonEnglishPct(): Promise<Map<string, number>> {
+  const { data, error } = await supabase
+    .from('census_language')
+    .select('community, total_pop_5plus, english_only');
+
+  if (error) throw new Error(`Failed to fetch language data: ${error.message}`);
+
+  // Aggregate by community
+  const agg = new Map<string, { totalPop: number; englishOnly: number }>();
+  for (const row of data) {
+    if (!row.community) continue;
+    const key = row.community.toUpperCase().trim();
+    const existing = agg.get(key) || { totalPop: 0, englishOnly: 0 };
+    existing.totalPop += Number(row.total_pop_5plus) || 0;
+    existing.englishOnly += Number(row.english_only) || 0;
+    agg.set(key, existing);
+  }
+
+  const pcts = new Map<string, number>();
+  for (const [community, stats] of agg) {
+    if (stats.totalPop <= 0) continue;
+    pcts.set(community, 1 - stats.englishOnly / stats.totalPop);
+  }
+
+  return pcts;
+}
+
+// Point-in-polygon (ray casting) — same algorithm as transit.ts
+function pointInPolygon(lat: number, lng: number, polygon: number[][]): boolean {
+  let inside = false;
+  for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
+    const [xi, yi] = polygon[i];
+    const [xj, yj] = polygon[j];
+    if ((yi > lat) !== (yj > lat) && lng < ((xj - xi) * (lat - yi)) / (yj - yi) + xi) {
+      inside = !inside;
+    }
+  }
+  return inside;
+}
+
+function pointInFeature(
+  lat: number,
+  lng: number,
+  geometry: { type: string; coordinates: number[][][] | number[][][][] },
+): boolean {
+  if (geometry.type === 'Polygon') {
+    return pointInPolygon(lat, lng, (geometry.coordinates as number[][][])[0]);
+  }
+  if (geometry.type === 'MultiPolygon') {
+    return (geometry.coordinates as number[][][][]).some((poly) =>
+      pointInPolygon(lat, lng, poly[0]),
+    );
+  }
+  return false;
+}
+
+async function computeAllScores(): Promise<Map<string, AccessGapResult>> {
+  logger.info('Computing access gap scores for all communities...');
+
+  const [engagementRates, transitScores, nonEnglishPcts] = await Promise.all([
+    fetchEngagementRates(),
+    fetchTransitScores(),
+    fetchNonEnglishPct(),
+  ]);
+
+  // Collect all known communities
+  const allCommunities = new Set<string>();
+  for (const key of engagementRates.keys()) allCommunities.add(key);
+  for (const key of transitScores.keys()) allCommunities.add(key);
+  for (const key of nonEnglishPcts.keys()) allCommunities.add(key);
+
+  // Build raw data per community
+  const rawData = new Map<string, CommunityRawData>();
+  for (const community of allCommunities) {
+    rawData.set(community, {
+      engagementRate: engagementRates.get(community) ?? null,
+      transitScore: transitScores.get(community) ?? null,
+      nonEnglishPct: nonEnglishPcts.get(community) ?? null,
+    });
+  }
+
+  // Compute min/max for normalization (only across communities with data)
+  const engagementValues = Array.from(rawData.values())
+    .map((d) => d.engagementRate)
+    .filter((v): v is number => v !== null);
+  const transitValues = Array.from(rawData.values())
+    .map((d) => d.transitScore)
+    .filter((v): v is number => v !== null);
+  const nonEnglishValues = Array.from(rawData.values())
+    .map((d) => d.nonEnglishPct)
+    .filter((v): v is number => v !== null);
+
+  const engMin = Math.min(...engagementValues);
+  const engMax = Math.max(...engagementValues);
+  const transMin = Math.min(...transitValues);
+  const transMax = Math.max(...transitValues);
+  const nelMin = Math.min(...nonEnglishValues);
+  const nelMax = Math.max(...nonEnglishValues);
+
+  // Compute composite scores
+  // Weights: low engagement 0.35, low transit 0.30, high non-English 0.35
+  // (Adjusted from issue spec since we only have 3 signals, not 5)
+  const WEIGHT_ENGAGEMENT = 0.35;
+  const WEIGHT_TRANSIT = 0.30;
+  const WEIGHT_NON_ENGLISH = 0.35;
+
+  const scored: { community: string; score: number; signals: AccessGapResult['signals'] }[] = [];
+
+  for (const [community, data] of rawData) {
+    let signalCount = 0;
+    let weightedSum = 0;
+    let totalWeight = 0;
+
+    const signals: AccessGapResult['signals'] = {
+      lowEngagement: null,
+      lowTransit: null,
+      highNonEnglish: null,
+    };
+
+    // Low 311 engagement → higher gap score
+    if (data.engagementRate !== null) {
+      const norm = normalize(data.engagementRate, engMin, engMax);
+      signals.lowEngagement = Math.round((1 - norm) * 100) / 100;
+      weightedSum += (1 - norm) * WEIGHT_ENGAGEMENT;
+      totalWeight += WEIGHT_ENGAGEMENT;
+      signalCount++;
+    }
+
+    // Low transit score → higher gap score
+    if (data.transitScore !== null) {
+      const norm = normalize(data.transitScore, transMin, transMax);
+      signals.lowTransit = Math.round((1 - norm) * 100) / 100;
+      weightedSum += (1 - norm) * WEIGHT_TRANSIT;
+      totalWeight += WEIGHT_TRANSIT;
+      signalCount++;
+    }
+
+    // High non-English percentage → higher gap score
+    if (data.nonEnglishPct !== null) {
+      const norm = normalize(data.nonEnglishPct, nelMin, nelMax);
+      signals.highNonEnglish = Math.round(norm * 100) / 100;
+      weightedSum += norm * WEIGHT_NON_ENGLISH;
+      totalWeight += WEIGHT_NON_ENGLISH;
+      signalCount++;
+    }
+
+    // Need at least 2 signals for a meaningful score
+    if (signalCount < 2) continue;
+
+    // Normalize by total weight used (handles missing signals gracefully)
+    const score = Math.round((weightedSum / totalWeight) * 100);
+    scored.push({ community, score, signals });
+  }
+
+  // Sort by score descending to assign ranks
+  scored.sort((a, b) => b.score - a.score);
+
+  const results = new Map<string, AccessGapResult>();
+  for (let i = 0; i < scored.length; i++) {
+    const { community, score, signals } = scored[i];
+    results.set(community, {
+      accessGapScore: score,
+      signals,
+      rank: i + 1,
+      totalCommunities: scored.length,
+    });
+  }
+
+  logger.info(`Computed access gap scores for ${results.size} communities`);
+  return results;
+}
+
+export async function getAccessGapScores(): Promise<Map<string, AccessGapResult>> {
+  const now = Date.now();
+  if (scoresCache && now - scoresCachedAt < CACHE_TTL) {
+    return scoresCache;
+  }
+  scoresCache = await computeAllScores();
+  scoresCachedAt = now;
+  return scoresCache;
+}
+
+export async function getAccessGapScore(community: string): Promise<AccessGapResult | null> {
+  const scores = await getAccessGapScores();
+  return scores.get(community.toUpperCase().trim()) ?? null;
+}
+
+export async function getTopUnderserved(limit = 10): Promise<
+  { community: string; accessGapScore: number; signals: AccessGapResult['signals'] }[]
+> {
+  const scores = await getAccessGapScores();
+  return Array.from(scores.entries())
+    .sort(([, a], [, b]) => b.accessGapScore - a.accessGapScore)
+    .slice(0, limit)
+    .map(([community, data]) => ({
+      community,
+      accessGapScore: data.accessGapScore,
+      signals: data.signals,
+    }));
+}

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -44,6 +44,16 @@ export function getDemographics(tractOrCommunity: string): Promise<NeighborhoodP
   return fetchJSON(`${BASE}/demographics?community=${encodeURIComponent(tractOrCommunity)}`);
 }
 
+export function getAccessGap(community: string): Promise<NonNullable<NeighborhoodProfile['accessGap']>> {
+  return fetchJSON(`${BASE}/access-gap?community=${encodeURIComponent(community)}`);
+}
+
+export function getAccessGapRanking(limit = 10): Promise<{
+  ranking: { community: string; accessGapScore: number; signals: NonNullable<NeighborhoodProfile['accessGap']>['signals'] }[];
+}> {
+  return fetchJSON(`${BASE}/access-gap/ranking?limit=${limit}`);
+}
+
 export function generateBrief(profile: NeighborhoodProfile, language: string): Promise<CommunityBrief> {
   return fetchJSON(`${BASE}/brief/generate`, {
     method: 'POST',

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -14,6 +14,7 @@ interface SidebarProps {
   briefError: string | null;
   topLanguages?: { language: string; percentage: number }[];
   transitScore?: NeighborhoodProfile['transit'] | null;
+  accessGap?: NeighborhoodProfile['accessGap'];
 }
 
 function LoadingSpinner({ label }: { label: string }) {
@@ -69,6 +70,7 @@ export default function Sidebar({
   briefError,
   topLanguages,
   transitScore,
+  accessGap,
 }: SidebarProps) {
   const [showDetails, setShowDetails] = useState(false);
   const { t, briefLang, setBriefLang } = useLanguage();
@@ -200,6 +202,54 @@ export default function Sidebar({
                 {transitScore.agencies.length > 0 && (
                   <> ({transitScore.agencies.join(', ')})</>
                 )}.
+              </p>
+            </section>
+          )}
+
+          {/* Access gap score */}
+          {accessGap && accessGap.accessGapScore != null && (
+            <section aria-labelledby="access-gap-heading" className="rounded-lg bg-amber-50 border border-amber-200 p-3">
+              <h2 id="access-gap-heading" className="text-sm font-medium text-amber-800 mb-2">
+                Access Gap Assessment
+              </h2>
+              <div className="flex items-center gap-3 mb-2">
+                <div className="text-2xl font-bold text-amber-700">{accessGap.accessGapScore}</div>
+                <div className="text-xs text-amber-600">
+                  <span className="block">/ 100</span>
+                  <span className="block">
+                    Rank {accessGap.rank} of {accessGap.totalCommunities} communities
+                  </span>
+                </div>
+              </div>
+              <p className="text-sm text-amber-700 mb-2">
+                {accessGap.accessGapScore >= 65
+                  ? 'Data patterns suggest this neighborhood may face significant access barriers to civic services.'
+                  : accessGap.accessGapScore >= 40
+                    ? 'Some indicators suggest potential access gaps in this neighborhood.'
+                    : 'This neighborhood shows relatively fewer signs of access barriers.'}
+              </p>
+              <div className="space-y-1.5 text-xs text-amber-600">
+                {accessGap.signals.lowEngagement != null && (
+                  <div className="flex justify-between">
+                    <span>Low civic engagement signal</span>
+                    <span className="font-mono">{Math.round(accessGap.signals.lowEngagement * 100)}%</span>
+                  </div>
+                )}
+                {accessGap.signals.lowTransit != null && (
+                  <div className="flex justify-between">
+                    <span>Limited transit access signal</span>
+                    <span className="font-mono">{Math.round(accessGap.signals.lowTransit * 100)}%</span>
+                  </div>
+                )}
+                {accessGap.signals.highNonEnglish != null && (
+                  <div className="flex justify-between">
+                    <span>Language barrier signal</span>
+                    <span className="font-mono">{Math.round(accessGap.signals.highNonEnglish * 100)}%</span>
+                  </div>
+                )}
+              </div>
+              <p className="text-xs text-amber-500 mt-2 italic">
+                This score identifies potential access gaps based on available data. It does not prove a neighborhood is underserved.
               </p>
             </section>
           )}

--- a/src/pages/neighborhood-page.tsx
+++ b/src/pages/neighborhood-page.tsx
@@ -3,7 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import SanDiegoMap from '../components/map/san-diego-map';
 import NeighborhoodSelector from '../components/ui/neighborhood-selector';
 import Sidebar from '../components/ui/sidebar';
-import { getLibraries, getRecCenters, getTransitStops, get311, getDemographics, generateBrief, getNeighborhoodBoundaries, getTransitScore } from '../api/client';
+import { getLibraries, getRecCenters, getTransitStops, get311, getDemographics, generateBrief, getNeighborhoodBoundaries, getTransitScore, getAccessGap } from '../api/client';
 import type { CommunityAnchor, CommunityBrief, NeighborhoodProfile, TransitStop } from '../types';
 import type { FeatureCollection } from 'geojson';
 import { useLanguage } from '../i18n/context';
@@ -30,6 +30,7 @@ export default function NeighborhoodPage() {
   const [topLanguages, setTopLanguages] = useState<{ language: string; percentage: number }[]>([]);
 
   const [transitScore, setTransitScore] = useState<NeighborhoodProfile['transit'] | null>(null);
+  const [accessGap, setAccessGap] = useState<NeighborhoodProfile['accessGap']>(null);
   const [dataError, setDataError] = useState<string | null>(null);
 
   const [brief, setBrief] = useState<CommunityBrief | null>(null);
@@ -62,6 +63,7 @@ export default function NeighborhoodPage() {
       setBrief(null);
       setTopLanguages([]);
       setTransitScore(null);
+      setAccessGap(null);
       return;
     }
 
@@ -70,6 +72,7 @@ export default function NeighborhoodPage() {
     setBrief(null);
     setTopLanguages([]);
     setTransitScore(null);
+    setAccessGap(null);
 
     get311(selectedCommunity)
       .then(setMetrics)
@@ -79,6 +82,10 @@ export default function NeighborhoodPage() {
     getTransitScore(selectedCommunity)
       .then(setTransitScore)
       .catch(() => { /* transit score may not be available */ });
+
+    getAccessGap(selectedCommunity)
+      .then((data) => { if (data?.accessGapScore != null) setAccessGap(data); })
+      .catch(() => { /* access gap score may not be available */ });
 
     // Try to fetch demographics for language suggestion
     getDemographics(selectedCommunity)
@@ -131,6 +138,7 @@ export default function NeighborhoodPage() {
       metrics,
       transit: transitScore ?? { nearbyStopCount: 0, nearestStopDistance: 0, stopCount: 0, agencyCount: 0, agencies: [], transitScore: 0, cityAverage: 0 },
       demographics: { topLanguages },
+      accessGap: accessGap ?? null,
     };
 
     setBriefLoading(true);
@@ -144,7 +152,7 @@ export default function NeighborhoodPage() {
     } finally {
       setBriefLoading(false);
     }
-  }, [selectedCommunity, selectedAnchor, metrics, topLanguages, transitScore]);
+  }, [selectedCommunity, selectedAnchor, metrics, topLanguages, transitScore, accessGap]);
 
   return (
     <div className="flex flex-col h-full md:flex-row print:block">
@@ -199,6 +207,7 @@ export default function NeighborhoodPage() {
             briefError={briefError}
             topLanguages={topLanguages}
             transitScore={transitScore}
+            accessGap={accessGap}
           />
         </div>
       </aside>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -36,6 +36,16 @@ export interface NeighborhoodProfile {
   demographics: {
     topLanguages: { language: string; percentage: number }[];
   };
+  accessGap?: {
+    accessGapScore: number;
+    signals: {
+      lowEngagement: number | null;
+      lowTransit: number | null;
+      highNonEnglish: number | null;
+    };
+    rank: number;
+    totalCommunities: number;
+  } | null;
 }
 
 export interface TransitStop {


### PR DESCRIPTION
## Summary

- Adds a composite "access gap" score (0-100) per community that combines three independent signals: low 311 engagement rate, low transit accessibility, and high non-English speaking percentage
- Each signal is min-max normalized across all San Diego communities, weighted (35%/30%/35%), and cached for 24 hours
- New API endpoints: `GET /api/access-gap?community={name}` and `GET /api/access-gap/ranking?limit={n}`
- Sidebar displays the score with appropriately cautious language ("may face access barriers," "patterns suggest," "does not prove")

Closes #19
Depends on #18 (transit score, cherry-picked into this branch)

## Test plan

- [ ] Select a neighborhood and verify the access gap section appears in the sidebar with a score 0-100
- [ ] Verify individual signal breakdowns (engagement, transit, language) are shown
- [ ] Verify cautious/hedged language is used throughout (no definitive claims)
- [ ] Hit `GET /api/access-gap/ranking?limit=5` and confirm a ranked list is returned
- [ ] Confirm communities with insufficient data (< 2 signals) do not receive a score
- [ ] Verify scores are cached (second request should be fast)

🤖 Generated with [Claude Code](https://claude.com/claude-code)