### PR TITLE
Use server-side aggregation for 311 metrics via Supabase RPC

### DIFF
--- a/server/routes/metrics.ts
+++ b/server/routes/metrics.ts
@@ -18,71 +18,33 @@ router.get('/', async (req, res) => {
     return;
   }
 
-  const { data, error } = await supabase
-    .from('requests_311')
-    .select('service_name, status, date_requested, date_closed, case_age_days')
-    .ilike('comm_plan_name', cleaned);
+  const { data, error } = await supabase.rpc('get_community_metrics', {
+    community_name: cleaned,
+  });
 
   if (error) {
-    logger.error('Failed to fetch 311 data', { error: error.message, community });
+    logger.error('Failed to fetch 311 metrics', { error: error.message, community });
     res.status(500).json({ error: 'Internal server error' });
     return;
   }
 
-  // Fetch population for this community from census data
-  const { data: censusData } = await supabase
-    .from('census_language')
-    .select('total_pop_5plus')
-    .ilike('community', cleaned);
+  const metrics = data as {
+    total_requests: number;
+    resolved_count: number;
+    avg_days_to_resolve: number;
+    top_issues: { category: string; count: number }[];
+    recently_resolved: { category: string; date: string }[];
+    recent_resolved_90d: number;
+    top_recent_category: string | null;
+    top_recent_category_count: number;
+    high_res_categories: { category: string; total: number; resolved: number; resolution_rate: number }[];
+    population: number;
+  };
 
-  const population = censusData
-    ? censusData.reduce((sum, row) => sum + (Number(row.total_pop_5plus) || 0), 0)
-    : 0;
-
-  const total = data.length;
-  const resolved = data.filter(
-    (r) => r.status === 'Closed' || r.date_closed
-  );
-  const resolvedCount = resolved.length;
+  const total = metrics.total_requests;
+  const resolvedCount = metrics.resolved_count;
   const resolutionRate = total > 0 ? resolvedCount / total : 0;
-
-  const daysToResolve = resolved
-    .filter((r) => r.date_requested && r.date_closed)
-    .map((r) => {
-      const requested = new Date(r.date_requested).getTime();
-      const closed = new Date(r.date_closed).getTime();
-      return (closed - requested) / (1000 * 60 * 60 * 24);
-    })
-    .filter((d) => d >= 0);
-  const avgDaysToResolve =
-    daysToResolve.length > 0
-      ? daysToResolve.reduce((a, b) => a + b, 0) / daysToResolve.length
-      : 0;
-
-  // Top issues by service_name
-  const issueCounts: Record<string, number> = {};
-  for (const r of data) {
-    const cat = r.service_name || 'Unknown';
-    issueCounts[cat] = (issueCounts[cat] || 0) + 1;
-  }
-  const topIssues = Object.entries(issueCounts)
-    .sort(([, a], [, b]) => b - a)
-    .slice(0, 10)
-    .map(([category, count]) => ({ category, count }));
-
-  // Recently resolved (last 5)
-  const recentlyResolved = resolved
-    .filter((r) => r.date_closed)
-    .sort(
-      (a, b) =>
-        new Date(b.date_closed).getTime() - new Date(a.date_closed).getTime()
-    )
-    .slice(0, 5)
-    .map((r) => ({
-      category: r.service_name || 'Unknown',
-      date: r.date_closed,
-    }));
-
+  const population = metrics.population;
   const requestsPer1000Residents =
     population > 0
       ? Math.round((total / population) * 1000 * 10) / 10
@@ -90,43 +52,19 @@ router.get('/', async (req, res) => {
 
   // --- Good news detection ---
   const goodNews: string[] = [];
-  const now = Date.now();
-  const NINETY_DAYS = 90 * 24 * 60 * 60 * 1000;
 
   // 1. Recently resolved issues in last 90 days
-  const recentResolved = resolved.filter((r) => {
-    if (!r.date_closed) return false;
-    return now - new Date(r.date_closed).getTime() < NINETY_DAYS;
-  });
-  if (recentResolved.length > 0) {
-    // Group by category to find the top resolved category
-    const recentCounts: Record<string, number> = {};
-    for (const r of recentResolved) {
-      const cat = r.service_name || 'Unknown';
-      recentCounts[cat] = (recentCounts[cat] || 0) + 1;
-    }
-    const topResolved = Object.entries(recentCounts).sort(([, a], [, b]) => b - a)[0];
+  if (metrics.recent_resolved_90d > 0 && metrics.top_recent_category) {
     goodNews.push(
-      `${recentResolved.length} issues were resolved in the last 90 days. The most common fix: ${topResolved[0]} (${topResolved[1]} resolved).`
+      `${metrics.recent_resolved_90d} issues were resolved in the last 90 days. The most common fix: ${metrics.top_recent_category} (${metrics.top_recent_category_count} resolved).`
     );
   }
 
-  // 2. Categories with high resolution rates (≥90%, minimum 10 reports)
-  const categoryStats: Record<string, { total: number; resolved: number }> = {};
-  for (const r of data) {
-    const cat = r.service_name || 'Unknown';
-    if (!categoryStats[cat]) categoryStats[cat] = { total: 0, resolved: 0 };
-    categoryStats[cat].total++;
-    if (r.status === 'Closed' || r.date_closed) categoryStats[cat].resolved++;
-  }
-  const highResCategories = Object.entries(categoryStats)
-    .filter(([, s]) => s.total >= 10 && s.resolved / s.total >= 0.9)
-    .sort(([, a], [, b]) => b.resolved / b.total - a.resolved / a.total);
-  if (highResCategories.length > 0) {
-    const [cat, stats] = highResCategories[0];
-    const rate = Math.round((stats.resolved / stats.total) * 100);
+  // 2. Categories with high resolution rates (>=90%, minimum 10 reports)
+  if (metrics.high_res_categories.length > 0) {
+    const top = metrics.high_res_categories[0];
     goodNews.push(
-      `${cat} reports are resolved ${rate}% of the time in this neighborhood.`
+      `${top.category} reports are resolved ${top.resolution_rate}% of the time in this neighborhood.`
     );
   }
 
@@ -148,9 +86,9 @@ router.get('/', async (req, res) => {
     totalRequests311: total,
     resolvedCount,
     resolutionRate,
-    avgDaysToResolve: Math.round(avgDaysToResolve * 10) / 10,
-    topIssues,
-    recentlyResolved,
+    avgDaysToResolve: metrics.avg_days_to_resolve,
+    topIssues: metrics.top_issues,
+    recentlyResolved: metrics.recently_resolved,
     population,
     requestsPer1000Residents,
     goodNews,

--- a/supabase/migrations/00003_add_community_metrics_rpc.sql
+++ b/supabase/migrations/00003_add_community_metrics_rpc.sql
@@ -1,0 +1,121 @@
+-- RPC function to aggregate 311 metrics for a community server-side.
+-- This avoids Supabase's default 1,000-row limit by computing all
+-- aggregates in Postgres and returning a single JSONB result.
+
+CREATE OR REPLACE FUNCTION get_community_metrics(community_name TEXT)
+RETURNS JSONB AS $$
+DECLARE
+  result JSONB;
+  cleaned TEXT;
+BEGIN
+  cleaned := replace(replace(community_name, '%', ''), '_', '');
+
+  SELECT jsonb_build_object(
+    'total_requests', COALESCE(agg.total, 0),
+    'resolved_count', COALESCE(agg.resolved, 0),
+    'avg_days_to_resolve', COALESCE(ROUND(agg.avg_days::numeric, 1), 0),
+    'top_issues', COALESCE(ti.items, '[]'::jsonb),
+    'recently_resolved', COALESCE(rr.items, '[]'::jsonb),
+    'recent_resolved_90d', COALESCE(r90.cnt, 0),
+    'top_recent_category', r90.top_cat,
+    'top_recent_category_count', COALESCE(r90.top_cat_cnt, 0),
+    'high_res_categories', COALESCE(hrc.items, '[]'::jsonb),
+    'population', COALESCE(pop.total, 0)
+  ) INTO result
+  FROM
+    -- Basic aggregates
+    (SELECT
+      COUNT(*) AS total,
+      COUNT(*) FILTER (WHERE status = 'Closed' OR date_closed IS NOT NULL) AS resolved,
+      AVG(EXTRACT(EPOCH FROM (date_closed - date_requested)) / 86400)
+        FILTER (WHERE date_closed IS NOT NULL AND date_requested IS NOT NULL
+                AND date_closed >= date_requested) AS avg_days
+    FROM requests_311
+    WHERE LOWER(comm_plan_name) = LOWER(cleaned)
+    ) agg,
+
+    -- Top 10 issues by service_name
+    LATERAL (
+      SELECT jsonb_agg(row_to_json(t)::jsonb) AS items FROM (
+        SELECT service_name AS category, COUNT(*) AS count
+        FROM requests_311
+        WHERE LOWER(comm_plan_name) = LOWER(cleaned)
+        GROUP BY service_name
+        ORDER BY count DESC
+        LIMIT 10
+      ) t
+    ) ti,
+
+    -- Last 5 recently resolved
+    LATERAL (
+      SELECT jsonb_agg(row_to_json(t)::jsonb) AS items FROM (
+        SELECT service_name AS category, date_closed AS date
+        FROM requests_311
+        WHERE LOWER(comm_plan_name) = LOWER(cleaned)
+          AND date_closed IS NOT NULL
+          AND (status = 'Closed' OR date_closed IS NOT NULL)
+        ORDER BY date_closed DESC
+        LIMIT 5
+      ) t
+    ) rr,
+
+    -- Resolved in last 90 days + top category
+    LATERAL (
+      SELECT
+        cnt,
+        top_cat,
+        top_cat_cnt
+      FROM (
+        SELECT COUNT(*) AS cnt
+        FROM requests_311
+        WHERE LOWER(comm_plan_name) = LOWER(cleaned)
+          AND (status = 'Closed' OR date_closed IS NOT NULL)
+          AND date_closed >= NOW() - INTERVAL '90 days'
+      ) c,
+      LATERAL (
+        SELECT service_name AS top_cat, COUNT(*) AS top_cat_cnt
+        FROM requests_311
+        WHERE LOWER(comm_plan_name) = LOWER(cleaned)
+          AND (status = 'Closed' OR date_closed IS NOT NULL)
+          AND date_closed >= NOW() - INTERVAL '90 days'
+        GROUP BY service_name
+        ORDER BY COUNT(*) DESC
+        LIMIT 1
+      ) tc
+    ) r90,
+
+    -- Categories with >= 90% resolution rate and >= 10 reports
+    LATERAL (
+      SELECT jsonb_agg(row_to_json(t)::jsonb) AS items FROM (
+        SELECT
+          service_name AS category,
+          COUNT(*) AS total,
+          COUNT(*) FILTER (WHERE status = 'Closed' OR date_closed IS NOT NULL) AS resolved,
+          ROUND(
+            COUNT(*) FILTER (WHERE status = 'Closed' OR date_closed IS NOT NULL)::numeric
+            / COUNT(*)::numeric * 100
+          ) AS resolution_rate
+        FROM requests_311
+        WHERE LOWER(comm_plan_name) = LOWER(cleaned)
+        GROUP BY service_name
+        HAVING COUNT(*) >= 10
+          AND COUNT(*) FILTER (WHERE status = 'Closed' OR date_closed IS NOT NULL)::numeric
+              / COUNT(*)::numeric >= 0.9
+        ORDER BY COUNT(*) FILTER (WHERE status = 'Closed' OR date_closed IS NOT NULL)::numeric
+              / COUNT(*)::numeric DESC
+      ) t
+    ) hrc,
+
+    -- Population from census
+    LATERAL (
+      SELECT COALESCE(SUM(total_pop_5plus), 0) AS total
+      FROM census_language
+      WHERE LOWER(community) = LOWER(cleaned)
+    ) pop;
+
+  RETURN result;
+END;
+$$ LANGUAGE plpgsql STABLE SECURITY DEFINER;
+
+-- Allow anon to call this function
+GRANT EXECUTE ON FUNCTION get_community_metrics(TEXT) TO anon;


### PR DESCRIPTION
## Summary
- Created `get_community_metrics()` Supabase RPC function that performs all 311 data aggregation in Postgres
- Updated `server/routes/metrics.ts` to call the RPC instead of fetching individual rows
- Fixes the 1,000-row cap from Supabase's default limit — Mira Mesa now correctly returns 10,895 requests

Fixes #43

## Test plan
- [x] Verified Mira Mesa returns 10,895 total requests (was capped at 1,000)
- [x] Verified good news detection works with aggregated data
- [x] Verified top issues and recently resolved display correctly in the UI
- [x] No console errors from the metrics endpoint
- [x] Server TypeScript compiles cleanly