### PR TITLE
Redesign printed flyer as infographic-style community flyer (#42)

### DIFF
--- a/src/components/brief/brief-display.tsx
+++ b/src/components/brief/brief-display.tsx
@@ -1,4 +1,4 @@
-import type { CommunityBrief } from '../../types/index';
+import type { CommunityBrief, NeighborhoodProfile } from '../../types/index';
 import { useLanguage } from '../../i18n/context';
 import { BriefFlyer } from './brief-flyer';
 import { toSlug } from '../../utils/slug';
@@ -6,9 +6,11 @@ import { toSlug } from '../../utils/slug';
 interface BriefDisplayProps {
   brief: CommunityBrief | null;
   loading: boolean;
+  metrics?: NeighborhoodProfile['metrics'] | null;
+  topLanguages?: { language: string; percentage: number }[];
 }
 
-export default function BriefDisplay({ brief, loading }: BriefDisplayProps) {
+export default function BriefDisplay({ brief, loading, metrics, topLanguages }: BriefDisplayProps) {
   const { t } = useLanguage();
 
   if (loading) {
@@ -138,6 +140,8 @@ export default function BriefDisplay({ brief, loading }: BriefDisplayProps) {
       <BriefFlyer
         brief={brief}
         neighborhoodSlug={toSlug(brief.neighborhoodName)}
+        metrics={metrics}
+        topLanguages={topLanguages}
       />
     </>
   );

--- a/src/components/brief/brief-flyer.tsx
+++ b/src/components/brief/brief-flyer.tsx
@@ -1,20 +1,28 @@
 import { QRCodeSVG } from 'qrcode.react';
-import type { CommunityBrief } from '../../types/index';
+import type { CommunityBrief, NeighborhoodProfile } from '../../types/index';
 import {
-  MegaphoneIcon,
-  AlertTriangleIcon,
-  HandRaisedIcon,
-  PhoneIcon,
-  MapPinIcon,
+  CheckCircleIcon,
+  SmartphoneIcon,
   BuildingIcon,
+  MapPinIcon,
+  GlobeIcon,
 } from './flyer-icons';
 
 interface BriefFlyerProps {
   brief: CommunityBrief;
   neighborhoodSlug: string;
+  metrics?: NeighborhoodProfile['metrics'] | null;
+  topLanguages?: { language: string; percentage: number }[];
 }
 
-export function BriefFlyer({ brief, neighborhoodSlug }: BriefFlyerProps) {
+/** Truncate text to roughly N sentences. */
+function truncateSentences(text: string, max: number): string {
+  const sentences = text.match(/[^.!?]+[.!?]+/g);
+  if (!sentences || sentences.length <= max) return text;
+  return sentences.slice(0, max).join('').trim();
+}
+
+export function BriefFlyer({ brief, neighborhoodSlug, metrics, topLanguages }: BriefFlyerProps) {
   const formattedDate = new Date(brief.generatedAt).toLocaleDateString('en-US', {
     year: 'numeric',
     month: 'long',
@@ -23,107 +31,189 @@ export function BriefFlyer({ brief, neighborhoodSlug }: BriefFlyerProps) {
 
   const qrUrl = `${window.location.origin}/neighborhood/${neighborhoodSlug}`;
 
+  const resolutionPct = metrics ? Math.round(metrics.resolutionRate * 100) : null;
+  const avgDays = metrics ? Math.round(metrics.avgDaysToResolve) : null;
+  const topIssuesData = metrics?.topIssues.slice(0, 3) ?? [];
+  const maxIssueCount = topIssuesData[0]?.count ?? 1;
+
+  const languagesForDisplay = (topLanguages ?? [])
+    .filter((l) => l.language !== 'English' && l.percentage > 3)
+    .slice(0, 4);
+
   return (
-    <div className="brief-flyer hidden print:block text-black">
-      {/* Header Banner */}
-      <div className="border-b-4 border-black pb-2 mb-3">
-        <p className="text-xs font-bold uppercase tracking-[0.3em]">Block Report</p>
-        <h1 className="text-3xl font-black uppercase leading-tight">
+    <div className="brief-flyer hidden text-black font-sans">
+
+      {/* ── TOP BANNER ── */}
+      <div className="border-b-4 border-black pb-3 mb-4">
+        <p className="text-[11px] font-bold uppercase tracking-[0.35em] mb-1">Block Report</p>
+        <h1 className="text-[32px] font-black leading-none">
           {brief.neighborhoodName}
         </h1>
-        <p className="text-sm font-medium">
-          Community Brief &middot; {formattedDate} &middot; {brief.language}
+        <p className="text-[15px] mt-1.5 font-medium">
+          {formattedDate}
         </p>
       </div>
 
-      {/* Summary */}
-      <div className="mb-3">
-        <p className="text-sm leading-snug">{brief.summary}</p>
-      </div>
+      {/* ── NARRATIVE HOOK ── */}
+      <p className="text-[13px] leading-relaxed mb-4">
+        {truncateSentences(brief.summary, 2)}
+      </p>
 
-      {/* Two-column: Good News + Top Issues */}
-      <div className="grid grid-cols-2 gap-4 mb-3">
-        <div className="flyer-section border-2 border-black rounded p-2">
-          <div className="flex items-center gap-1.5 mb-1.5 border-b border-black pb-1">
-            <MegaphoneIcon className="w-4 h-4" />
-            <h2 className="text-xs font-black uppercase tracking-widest">Good News</h2>
+      {/* ── BIG NUMBER CARDS ── */}
+      {metrics && (
+        <div className="grid grid-cols-3 gap-4 mb-5">
+          <div className="border-2 border-black rounded-lg p-4 text-center">
+            <div className="text-[36px] font-black leading-none">
+              {metrics.totalRequests311.toLocaleString()}
+            </div>
+            <div className="text-[12px] mt-1.5 font-semibold uppercase tracking-wide">
+              Issues Reported
+            </div>
           </div>
-          <ul className="text-xs space-y-1 list-none">
-            {brief.goodNews.slice(0, 4).map((item, i) => (
-              <li key={i} className="flex gap-1">
-                <span className="font-bold flex-shrink-0">&bull;</span>
+          <div className="border-2 border-black rounded-lg p-4 text-center">
+            <div className="text-[36px] font-black leading-none">
+              {resolutionPct}%
+            </div>
+            <div className="text-[12px] mt-1.5 font-semibold uppercase tracking-wide">
+              Resolved
+            </div>
+          </div>
+          <div className="border-2 border-black rounded-lg p-4 text-center">
+            <div className="text-[36px] font-black leading-none">
+              {avgDays}
+            </div>
+            <div className="text-[12px] mt-1.5 font-semibold uppercase tracking-wide">
+              Avg Days to Fix
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* ── TWO-COLUMN: TOP ISSUES + GOOD NEWS ── */}
+      <div className="grid grid-cols-2 gap-5 mb-5">
+        {/* Top Issues — horizontal bars */}
+        <div className="flyer-section">
+          <h2 className="text-[15px] font-black uppercase tracking-widest border-b-2 border-black pb-1 mb-3">
+            Top Issues
+          </h2>
+          {topIssuesData.length > 0 ? (
+            <div className="space-y-3">
+              {topIssuesData.map((issue) => (
+                <div key={issue.category}>
+                  <div className="flex justify-between text-[13px] mb-1">
+                    <span className="font-medium">{issue.category}</span>
+                    <span className="font-bold tabular-nums">{issue.count}</span>
+                  </div>
+                  <div className="h-4 bg-gray-200 rounded-sm">
+                    <div
+                      className="h-4 bg-black rounded-sm"
+                      style={{ width: `${(issue.count / maxIssueCount) * 100}%` }}
+                    />
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <ul className="text-[13px] space-y-1.5 list-none">
+              {brief.topIssues.slice(0, 3).map((item, i) => (
+                <li key={i} className="flex gap-1">
+                  <span className="font-bold flex-shrink-0">&bull;</span>
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        {/* Good News — callout box */}
+        <div className="flyer-section border-2 border-black rounded-lg p-3">
+          <div className="flex items-center gap-2 mb-2">
+            <CheckCircleIcon className="w-5 h-5" />
+            <h2 className="text-[15px] font-black uppercase tracking-widest">Good News</h2>
+          </div>
+          <ul className="text-[12px] space-y-2 list-none">
+            {(metrics?.goodNews ?? brief.goodNews).slice(0, 2).map((item, i) => (
+              <li key={i} className="flex gap-2">
+                <span className="font-bold flex-shrink-0 text-[15px] leading-none">{'\u2713'}</span>
                 <span>{item}</span>
               </li>
             ))}
           </ul>
         </div>
-
-        <div className="flyer-section border-2 border-black rounded p-2">
-          <div className="flex items-center gap-1.5 mb-1.5 border-b border-black pb-1">
-            <AlertTriangleIcon className="w-4 h-4" />
-            <h2 className="text-xs font-black uppercase tracking-widest">Neighbors Report</h2>
-          </div>
-          <ul className="text-xs space-y-1 list-none">
-            {brief.topIssues.slice(0, 4).map((item, i) => (
-              <li key={i} className="flex gap-1">
-                <span className="font-bold flex-shrink-0">&bull;</span>
-                <span>{item}</span>
-              </li>
-            ))}
-          </ul>
-        </div>
       </div>
 
-      {/* How to Get Involved — full width */}
-      <div className="flyer-section border-2 border-black rounded p-2 mb-3">
-        <div className="flex items-center gap-1.5 mb-1.5 border-b border-black pb-1">
-          <HandRaisedIcon className="w-4 h-4" />
-          <h2 className="text-xs font-black uppercase tracking-widest">Get Involved</h2>
+      {/* ── LANGUAGES SPOKEN ── */}
+      {languagesForDisplay.length > 0 && (
+        <div className="flyer-section mb-5">
+          <div className="flex items-center gap-2 mb-2">
+            <GlobeIcon className="w-5 h-5" />
+            <h2 className="text-[15px] font-black uppercase tracking-widest">Languages Spoken</h2>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {languagesForDisplay.map((l) => (
+              <span
+                key={l.language}
+                className="border-2 border-black rounded-full px-4 py-1.5 text-[12px] font-semibold"
+              >
+                {l.language} {Math.round(l.percentage)}%
+              </span>
+            ))}
+          </div>
         </div>
-        <ul className="text-xs space-y-1 list-none">
-          {brief.howToParticipate.slice(0, 4).map((item, i) => (
-            <li key={i} className="flex gap-1">
-              <span className="font-bold flex-shrink-0">&bull;</span>
+      )}
+
+      {/* ── GET INVOLVED ── */}
+      <div className="flyer-section border-2 border-black rounded-lg p-4 mb-5">
+        <h2 className="text-[15px] font-black uppercase tracking-widest border-b border-black pb-1.5 mb-3">
+          Get Involved in {brief.neighborhoodName}
+        </h2>
+        <ul className="text-[12px] space-y-2 list-none mb-3">
+          {brief.howToParticipate.slice(0, 2).map((item, i) => (
+            <li key={i} className="flex gap-2">
+              <span className="font-bold flex-shrink-0">{'\u25B8'}</span>
               <span>{item}</span>
             </li>
           ))}
         </ul>
+        <div className="border-t border-black pt-2.5 grid grid-cols-3 gap-3 text-[11px]">
+          <div className="flex items-start gap-1.5">
+            <SmartphoneIcon className="w-4 h-4 mt-0.5 flex-shrink-0" />
+            <div>
+              <div className="font-bold">Report Issues</div>
+              <div>Call 311 / Get It Done app</div>
+            </div>
+          </div>
+          <div className="flex items-start gap-1.5">
+            <BuildingIcon className="w-4 h-4 mt-0.5 flex-shrink-0" />
+            <div>
+              <div className="font-bold">Council Rep</div>
+              <div>{brief.contactInfo.councilDistrict}</div>
+            </div>
+          </div>
+          <div className="flex items-start gap-1.5">
+            <MapPinIcon className="w-4 h-4 mt-0.5 flex-shrink-0" />
+            <div>
+              <div className="font-bold">Nearest Resource</div>
+              <div>{brief.contactInfo.anchorLocation}</div>
+            </div>
+          </div>
+        </div>
       </div>
 
-      {/* Footer: Contact + QR */}
-      <div className="grid grid-cols-[1fr_auto] gap-4 border-t-2 border-black pt-2">
-        <div className="flyer-section">
-          <h2 className="text-xs font-black uppercase tracking-widest mb-1.5">Contact</h2>
-          <dl className="text-xs space-y-1">
-            <div className="flex items-center gap-1.5">
-              <PhoneIcon className="w-3.5 h-3.5 flex-shrink-0" />
-              <dt className="sr-only">311 Phone</dt>
-              <dd>{brief.contactInfo.phone311}</dd>
-            </div>
-            <div className="flex items-center gap-1.5">
-              <BuildingIcon className="w-3.5 h-3.5 flex-shrink-0" />
-              <dt className="sr-only">Council District</dt>
-              <dd>{brief.contactInfo.councilDistrict}</dd>
-            </div>
-            <div className="flex items-center gap-1.5">
-              <MapPinIcon className="w-3.5 h-3.5 flex-shrink-0" />
-              <dt className="sr-only">Nearest Resource</dt>
-              <dd>{brief.contactInfo.anchorLocation}</dd>
-            </div>
-          </dl>
+      {/* ── FOOTER: QR + TAGLINE ── */}
+      <div className="flex items-end justify-between border-t-2 border-black pt-3">
+        <div>
+          <p className="text-[11px] font-medium">
+            Block Report &mdash; Your neighborhood, your voice
+          </p>
+          <p className="text-[10px] text-gray-600">
+            Generated {formattedDate} &middot; {window.location.origin}/resources
+          </p>
         </div>
-
         <div className="flex flex-col items-center">
           <QRCodeSVG value={qrUrl} size={72} level="M" />
-          <p className="text-[9px] mt-1 text-center font-medium">Scan to view online</p>
+          <p className="text-[9px] mt-1 text-center font-medium">Scan for full report</p>
         </div>
-      </div>
-
-      {/* Bottom tagline */}
-      <div className="border-t border-black mt-2 pt-1 text-center">
-        <p className="text-[9px] font-medium tracking-wide">
-          Block Report &middot; Your neighborhood, your voice &middot; More resources at {window.location.origin}/resources
-        </p>
       </div>
     </div>
   );

--- a/src/components/brief/flyer-icons.tsx
+++ b/src/components/brief/flyer-icons.tsx
@@ -67,3 +67,40 @@ export function BuildingIcon({ className = 'w-5 h-5' }: IconProps) {
     </svg>
   );
 }
+
+export function CheckCircleIcon({ className = 'w-5 h-5' }: IconProps) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
+      <polyline points="22 4 12 14.01 9 11.01" />
+    </svg>
+  );
+}
+
+export function SmartphoneIcon({ className = 'w-5 h-5' }: IconProps) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="5" y="2" width="14" height="20" rx="2" ry="2" />
+      <line x1="12" y1="18" x2="12.01" y2="18" />
+    </svg>
+  );
+}
+
+export function GlobeIcon({ className = 'w-5 h-5' }: IconProps) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="12" cy="12" r="10" />
+      <line x1="2" y1="12" x2="22" y2="12" />
+      <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
+    </svg>
+  );
+}
+
+export function ClipboardIcon({ className = 'w-5 h-5' }: IconProps) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2" />
+      <rect x="8" y="2" width="8" height="4" rx="1" ry="1" />
+    </svg>
+  );
+}

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -377,7 +377,7 @@ export default function Sidebar({
         </div>
       )}
 
-      <BriefDisplay brief={brief} loading={briefLoading} />
+      <BriefDisplay brief={brief} loading={briefLoading} metrics={metrics} topLanguages={topLanguages} />
     </div>
   );
 }

--- a/src/print.css
+++ b/src/print.css
@@ -2,7 +2,7 @@
 @media print {
   @page {
     size: letter portrait;
-    margin: 0.5in;
+    margin: 0.6in 0.7in;
   }
 
   /* Reset layout constraints for print */
@@ -11,26 +11,31 @@
     overflow: visible !important;
   }
 
-  /* Hide everything visually (but keep in flow so children can override) */
+  /* Hide everything visually but keep in flow */
   body * {
     visibility: hidden;
   }
 
-  /* Show the flyer and all its children */
-  .brief-flyer,
-  .brief-flyer * {
-    visibility: visible;
-  }
-
-  /* Position flyer at top-left, full width */
+  /* The flyer has display:none from Tailwind's "hidden" class — override it */
   .brief-flyer {
+    display: block !important;
+    visibility: visible;
     position: absolute;
     left: 0;
     top: 0;
     width: 100%;
+    padding: 0;
+    margin: 0;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
   }
 
-  /* Fully hide elements that should not occupy space at all */
+  /* Make all flyer children visible */
+  .brief-flyer * {
+    visibility: visible;
+  }
+
+  /* Fully remove elements that shouldn't occupy space */
   .no-print,
   .brief-content,
   nav[aria-label="Main navigation"],


### PR DESCRIPTION
## Summary
- Replaces text-heavy print layout with visual infographic: big number cards (total issues, resolution %, avg days), horizontal bar charts for top issues, language pills, and a personalized narrative hook
- Threads structured metrics data (`NeighborhoodProfile['metrics']` and `topLanguages`) from Sidebar through BriefDisplay to BriefFlyer for visual display
- Adds neighborhood-specific calls to action using Claude-generated `howToParticipate` items instead of generic text
- Fixes print CSS: overrides Tailwind's `hidden` class with `display: block !important`, adds `print-color-adjust: exact` for background rendering, proper `@page` margins
- Caps dynamic content (2-sentence summary, 2 good news items, 2 action items) and sizes up static elements (36px big numbers, 32px heading) to fill the page safely

Closes #42

## Test plan
- [ ] Select a neighborhood (e.g. Mira Mesa), generate a brief, click Print Brief
- [ ] Verify print preview shows infographic layout with big number cards, bar charts, good news callout, language pills, and personalized actions
- [ ] Verify it fits on one US Letter page with Default margins
- [ ] Verify it's readable in black and white (no color dependency)
- [ ] Test with a different neighborhood to confirm dynamic content doesn't overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)