### PR TITLE
Add transit travel time to City Hall estimate

### DIFF
--- a/server/routes/transit.ts
+++ b/server/routes/transit.ts
@@ -4,6 +4,44 @@ import { logger } from '../logger.js';
 
 const router = Router();
 
+const CITY_HALL = { lat: 32.7157, lng: -117.1611 };
+const WALKING_SPEED_MPH = 3;
+const BUS_SPEED_MPH = 12;
+const ROUTE_INDIRECTNESS = 1.4;
+
+function haversineDistanceMiles(lat1: number, lng1: number, lat2: number, lng2: number): number {
+  const R = 3958.8; // Earth radius in miles
+  const dLat = ((lat2 - lat1) * Math.PI) / 180;
+  const dLng = ((lng2 - lng1) * Math.PI) / 180;
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos((lat1 * Math.PI) / 180) * Math.cos((lat2 * Math.PI) / 180) * Math.sin(dLng / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+function computeCentroid(geometry: { type: string; coordinates: number[][][] | number[][][][] }): { lat: number; lng: number } | null {
+  let ring: number[][] = [];
+  if (geometry.type === 'Polygon') {
+    ring = (geometry.coordinates as number[][][])[0];
+  } else if (geometry.type === 'MultiPolygon') {
+    let maxLen = 0;
+    for (const poly of geometry.coordinates as number[][][][]) {
+      if (poly[0].length > maxLen) {
+        maxLen = poly[0].length;
+        ring = poly[0];
+      }
+    }
+  }
+  if (ring.length === 0) return null;
+  let latSum = 0;
+  let lngSum = 0;
+  for (const [lng, lat] of ring) {
+    latSum += lat;
+    lngSum += lng;
+  }
+  return { lat: latSum / ring.length, lng: lngSum / ring.length };
+}
+
 // Cache the computed transit scores for all communities (recompute every 24h)
 const CACHE_TTL = 24 * 60 * 60 * 1000;
 let scoresCache: Map<string, TransitScore> | null = null;
@@ -15,6 +53,7 @@ interface TransitScore {
   agencies: string[];
   rawScore: number;
   transitScore: number; // normalized 0-100
+  travelTimeToCityHall: number | null; // estimated minutes via transit
 }
 
 // Simple point-in-polygon (ray casting)
@@ -58,6 +97,18 @@ async function computeAllScores(): Promise<Map<string, TransitScore>> {
   if (!response.ok) throw new Error(`Failed to fetch boundaries: ${response.status}`);
   const geojson = await response.json();
 
+  // Pre-compute nearest stop to City Hall (used for all communities)
+  let nearestToCityHall: { lat: number; lng: number } | null = null;
+  let minDistCityHall = Infinity;
+  for (const stop of stops) {
+    if (stop.lat == null || stop.lng == null) continue;
+    const d = haversineDistanceMiles(CITY_HALL.lat, CITY_HALL.lng, stop.lat, stop.lng);
+    if (d < minDistCityHall) {
+      minDistCityHall = d;
+      nearestToCityHall = { lat: stop.lat, lng: stop.lng };
+    }
+  }
+
   const scores = new Map<string, TransitScore>();
 
   // For each community, count stops and unique agencies within its boundary
@@ -65,7 +116,7 @@ async function computeAllScores(): Promise<Map<string, TransitScore>> {
     const communityName: string = feature.properties?.cpname || feature.properties?.name || '';
     if (!communityName) continue;
 
-    const stopsInCommunity: { stop_agncy: string | null }[] = [];
+    const stopsInCommunity: { lat: number; lng: number; stop_agncy: string | null }[] = [];
     for (const stop of stops) {
       if (stop.lat == null || stop.lng == null) continue;
       // GeoJSON coordinates are [lng, lat]
@@ -85,12 +136,40 @@ async function computeAllScores(): Promise<Map<string, TransitScore>> {
     // Agency count is small (typically 1-3), so scale it up to be comparable with stop count
     const rawScore = stopCount * 0.4 + agencyCount * 10 * 0.6;
 
+    // Estimate travel time to City Hall
+    const centroid = computeCentroid(feature.geometry);
+    let travelTimeToCityHall: number | null = null;
+
+    if (centroid && stopsInCommunity.length > 0 && nearestToCityHall) {
+      // Find nearest stop to community centroid
+      let nearestToCentroid = stopsInCommunity[0];
+      let minDistCentroid = Infinity;
+      for (const stop of stopsInCommunity) {
+        const d = haversineDistanceMiles(centroid.lat, centroid.lng, stop.lat, stop.lng);
+        if (d < minDistCentroid) {
+          minDistCentroid = d;
+          nearestToCentroid = stop;
+        }
+      }
+
+      const walkToStop = (minDistCentroid / WALKING_SPEED_MPH) * 60;
+      const transitDist = haversineDistanceMiles(
+        nearestToCentroid.lat, nearestToCentroid.lng,
+        nearestToCityHall.lat, nearestToCityHall.lng
+      );
+      const transitTime = ((transitDist * ROUTE_INDIRECTNESS) / BUS_SPEED_MPH) * 60;
+      const walkFromStop = (minDistCityHall / WALKING_SPEED_MPH) * 60;
+
+      travelTimeToCityHall = Math.round(walkToStop + transitTime + walkFromStop);
+    }
+
     scores.set(communityName.toUpperCase(), {
       stopCount,
       agencyCount,
       agencies: Array.from(agencies),
       rawScore,
       transitScore: 0, // will normalize after
+      travelTimeToCityHall,
     });
   }
 
@@ -139,6 +218,7 @@ router.get('/', async (req, res) => {
         agencies: [],
         transitScore: 0,
         cityAverage: getCityAverage(scores),
+        travelTimeToCityHall: null,
       });
       return;
     }

--- a/server/services/claude.ts
+++ b/server/services/claude.ts
@@ -50,7 +50,7 @@ Generate a brief with these sections:
 3. **What Your Neighbors Are Reporting** — Top 3 issues being reported via 311, framed constructively (not as complaints, but as things the community is working on).
 4. **How to Get Involved** — 3-4 concrete actions: how to file a 311 report, how to attend council meetings, how to contact their council representative, where to find more info.
 5. **Nearby Resources** — List the closest libraries and rec centers with addresses, if available in the data.
-6. **Transit Info** — How many transit stops and routes serve the area.
+6. **Transit Info** — How many transit stops and routes serve the area, and the estimated transit travel time to City Hall if available.
 
 Keep the total brief under 400 words. It should fit on one printed page.`;
 

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -203,6 +203,12 @@ export default function Sidebar({
                   <> ({transitScore.agencies.join(', ')})</>
                 )}.
               </p>
+              {transitScore.travelTimeToCityHall != null && transitScore.travelTimeToCityHall > 0 && (
+                <p className="text-sm text-indigo-700 mt-1">
+                  Estimated travel time to City Hall:{' '}
+                  <span className="font-semibold">~{transitScore.travelTimeToCityHall} min</span>
+                </p>
+              )}
             </section>
           )}
 

--- a/src/pages/neighborhood-page.tsx
+++ b/src/pages/neighborhood-page.tsx
@@ -154,7 +154,7 @@ export default function NeighborhoodPage() {
       communityName: selectedCommunity,
       anchor,
       metrics,
-      transit: transitScore ?? { nearbyStopCount: 0, nearestStopDistance: 0, stopCount: 0, agencyCount: 0, agencies: [], transitScore: 0, cityAverage: 0 },
+      transit: transitScore ?? { nearbyStopCount: 0, nearestStopDistance: 0, stopCount: 0, agencyCount: 0, agencies: [], transitScore: 0, cityAverage: 0, travelTimeToCityHall: null },
       demographics: { topLanguages },
       accessGap: accessGap ?? null,
     };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -32,6 +32,7 @@ export interface NeighborhoodProfile {
     agencies: string[];
     transitScore: number;
     cityAverage: number;
+    travelTimeToCityHall: number | null;
   };
   demographics: {
     topLanguages: { language: string; percentage: number }[];


### PR DESCRIPTION
Fixes #52

## Summary
- Estimates transit travel time from each neighborhood to City Hall (202 C St) using haversine distances, walking speed (3 mph), and average bus speed (12 mph with 1.4x indirectness factor)
- Computation piggybacks on existing `computeAllScores()` loop — no new endpoints needed
- Displays in the Transit Access sidebar section
- Brief generation prompt updated to reference travel time

## Test plan
- [x] Verified Mira Mesa shows ~119 min (reasonable for northern suburb)
- [x] Verified Downtown shows ~4 min (near City Hall)
- [x] Verified Barrio Logan shows ~22 min (nearby neighborhood)
- [x] No new console errors